### PR TITLE
[WIP] Provider

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -1,4 +1,5 @@
 const { Component, PureComponent } = require('react');
+const ReactNContext = require('./context');
 const {
   ReactNComponentWillUnmount,
   ReactNGlobal,
@@ -15,6 +16,8 @@ const isSetGlobalCallback = false;
 // React.Component, React.PureComponent
 const createReactNClassComponent = Super =>
   class ReactNComponent extends Super {
+
+    static contextType = ReactNContext;
 
     constructor(...args) {
       super(...args);

--- a/src/context.js
+++ b/src/context.js
@@ -1,0 +1,4 @@
+const { createContext } = require('react');
+const GlobalState = require('./global-state');
+
+module.exports = createContext(new GlobalState());

--- a/src/global-state-instance.js
+++ b/src/global-state-instance.js
@@ -1,0 +1,3 @@
+const GlobalState = require('./global-state');
+
+module.exports = new GlobalState();

--- a/src/global-state.js
+++ b/src/global-state.js
@@ -1,9 +1,8 @@
 const objectGetListener = require('./object-get-listener');
-const reducers = require('./reducers');
 
 const MAX_SAFE_INTEGER = 9007199254740990;
 
-class GlobalStateManager {
+class GlobalState {
 
   constructor() {
     this.reset();
@@ -62,6 +61,7 @@ class GlobalStateManager {
   // Reset the global state.
   reset() {
     this._keyListeners = new Map();
+    this._reducers = Object.create(null);
     this._state = Object.create(null);
     this._transactionId = 0;
     this._transactions = new Map();
@@ -163,13 +163,17 @@ class GlobalStateManager {
     return Object.assign(
       Object.create(null),
       this.spyState(keyListener),
-      reducers
+      this._reducers
     );
   }
 
   get stateWithReducers() {
-    return Object.assign(Object.create(null), this._state, reducers);
+    return Object.assign(
+      Object.create(null),
+      this._state,
+      this._reducers
+    );
   }
 };
 
-module.exports = new GlobalStateManager();
+module.exports = GlobalState;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 const React = require('react');
 const { ReactNComponent, ReactNPureComponent } = require('./components');
+const { Provider } = require('./context');
 const ReactN = require('./decorator');
+const GlobalState = require('./global-state');
 const {
   addReducer, resetGlobal, setGlobal, useGlobal, withGlobal
 } = require('./helpers/index');
@@ -9,6 +11,8 @@ Object.assign(ReactN, React, {
   addReducer,
   Component: ReactNComponent,
   default: ReactN,
+  GlobalState,
+  Provider,
   PureComponent: ReactNPureComponent,
   resetGlobal,
   setGlobal,


### PR DESCRIPTION
Context needs to be backwards compatible. Add the `constructor(..., context)` alternative?
Make sure createContext doesn't crash if older version of React.

Maybe only provide a Provider property if the React version supports useable context in the first place.

Provide the relevant global state to the methods -- the one from the context, not the built-in instance if a context is provided.

Safe fallback if no context is provided.