### PR TITLE
Fix "React is undefined"

### DIFF
--- a/src/helpers/create-provider.js
+++ b/src/helpers/create-provider.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import React, { Component } from 'react';
 import Context from '../context';
 import GlobalState from '../global-state';
 import addReducer from './add-reducer';


### PR DESCRIPTION
The JSX gets translated to `React.createElement` during the build, so `React` needs to be imported.