### PR TITLE
[typescript] All tests passing with jest. Added a couple of tests for useGlobal.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,6 @@ module.exports = {
   resetModules: true,
   restoreMocks: true,
   roots: [ "<rootDir>/tests" ],
-  testRegex: '/tests/.*\\.test\\.tsx?$',
+  testRegex: '/tests/.+\\.test\\.tsx?$',
   verbose: true,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,6 @@ module.exports = {
   resetModules: true,
   restoreMocks: true,
   roots: [ "<rootDir>/tests" ],
-  testRegex: '/tests/add-callback\\.test\\.tsx?$',
+  testRegex: '/tests/.*\\.test\\.tsx?$',
   verbose: true,
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "jest": "^24.6.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-hooks-testing-library": "^0.4.0",
     "react-testing-library": "^6.0.4",
     "ts-jest": "^24.0.1",
     "ts-node": "^8.0.2",

--- a/tests/add-reducer.test.ts
+++ b/tests/add-reducer.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import addReducer from '../src/add-reducer';
 import GlobalStateManager from '../src/global-state-manager';
 import spyOn from './utils/spy-on-global-state-manager';
@@ -23,14 +22,14 @@ describe('addReducer', (): void => {
 
 
   it('should be a function with 3 arguments', (): void => {
-    expect(addReducer).to.be.a('function');
-    expect(addReducer.length).to.equal(3);
+    expect(addReducer).toEqual(expect.any(Function));
+    expect(addReducer).toHaveLength(3);
   });
 
   it('should call GlobalStateManager.addDispatcher', (): void => {
     addReducer(globalStateManager, REDUCER_NAME, REDUCER);
-    expect(spy.addDispatcher.calledOnceWithExactly(REDUCER_NAME, REDUCER))
-      .to.equal(true);
+    expect(spy.addDispatcher).toHaveBeenCalledTimes(1);
+    expect(spy.addDispatcher).toHaveBeenCalledWith(REDUCER_NAME, REDUCER);
   });
 
 
@@ -43,14 +42,14 @@ describe('addReducer', (): void => {
     });
 
     it('should be a function with no arguments', (): void => {
-      expect(removeReducer).to.be.a('function');
-      expect(removeReducer.length).to.equal(0);
+      expect(removeReducer).toEqual(expect.any(Function));
+      expect(removeReducer).toHaveLength(0);
     });
 
     it('should call GlobalStateManager.removeDispatcher', (): void => {
       removeReducer();
-      expect(spy.removeDispatcher.calledOnceWithExactly(REDUCER_NAME))
-        .to.equal(true);
+      expect(spy.removeDispatcher).toHaveBeenCalledTimes(1);
+      expect(spy.removeDispatcher).toHaveBeenCalledWith(REDUCER_NAME);
     });
   });
 

--- a/tests/add-reducers.test.ts
+++ b/tests/add-reducers.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import addReducers from '../src/add-reducers';
 import GlobalStateManager from '../src/global-state-manager';
 import { GS, INITIAL_REDUCERS, INITIAL_STATE } from './utils/initial';
@@ -24,18 +23,17 @@ describe('addReducers', (): void => {
 
 
   it('should be a function with 2 arguments', (): void => {
-    expect(addReducers).to.be.a('function');
-    expect(addReducers.length).to.equal(2);
+    expect(addReducers).toEqual(expect.any(Function));
+    expect(addReducers).toHaveLength(2);
   });
 
   it(
     'should call GlobalStateManager.addDispatcher for each reducer',
     (): void => {
       addReducers(globalStateManager, INITIAL_REDUCERS);
-      expect(spy.addDispatcher.callCount).to.equal(REDUCERS.length);
+      expect(spy.addDispatcher).toHaveBeenCalledTimes(REDUCERS.length);
       for (const [ name, reducer ] of REDUCERS) {
-        expect(spy.addDispatcher.calledWithExactly(name, reducer))
-          .to.equal(true);
+        expect(spy.addDispatcher).toHaveBeenCalledWith(name, reducer);
       }
     }
   );
@@ -50,24 +48,23 @@ describe('addReducers', (): void => {
     });
 
     it('should be a function with no arguments', (): void => {
-      expect(removeReducers).to.be.a('function');
-      expect(removeReducers.length).to.equal(0);
+      expect(removeReducers).toEqual(expect.any(Function));
+      expect(removeReducers).toHaveLength(0);
     });
 
     it(
       'should call GlobalStateManager.removeDispatcher for each reducer',
       (): void => {
         removeReducers();
-        expect(spy.removeDispatcher.callCount).to.equal(REDUCERS.length);
+        expect(spy.removeDispatcher).toHaveBeenCalledTimes(REDUCERS.length);
         for (const reducerName of REDUCER_NAMES) {
-          expect(spy.removeDispatcher.calledWithExactly(reducerName))
-            .to.equal(true);
+          expect(spy.removeDispatcher).toHaveBeenCalledWith(reducerName);
         }
       }
     );
 
     it('should return true', (): void => {
-      expect(removeReducers()).to.equal(true);
+      expect(removeReducers()).toBe(true);
     });
   });
 

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { Context, createContext } from 'react';
 import ReactNContext from '../src/context';
 import defaultGlobalStateManager from '../src/default-global-state-manager';
@@ -11,11 +10,11 @@ describe('ReactN Context', (): void => {
     const reactContext: Context<null> = createContext(null);
     const ReactContextPrototype = Object.getPrototypeOf(reactContext);
     const ReactNContextPrototype = Object.getPrototypeOf(ReactNContext);
-    expect(ReactNContextPrototype).to.equal(ReactContextPrototype);
+    expect(ReactNContextPrototype).toEqual(ReactContextPrototype);
   });
 
   it('should default to the default global state manager', (): void => {
-    expect(ReactNContext._currentValue).to.equal(defaultGlobalStateManager);
-    expect(ReactNContext._currentValue2).to.equal(defaultGlobalStateManager);
+    expect(ReactNContext._currentValue).toEqual(defaultGlobalStateManager);
+    expect(ReactNContext._currentValue2).toEqual(defaultGlobalStateManager);
   });
 });

--- a/tests/create-provider.test.ts
+++ b/tests/create-provider.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { Component } from 'react';
 import createProvider, { ReactNProvider } from '../src/create-provider';
 import { GS, INITIAL_REDUCERS, INITIAL_STATE, R } from './utils/initial';
@@ -8,8 +7,8 @@ import { GS, INITIAL_REDUCERS, INITIAL_STATE, R } from './utils/initial';
 describe('createProvider', (): void => {
 
   it('should be a function with 2 arguments', (): void => {
-    expect(createProvider).to.be.a('function');
-    expect(createProvider.length).to.equal(2);
+    expect(createProvider).toEqual(expect.any(Function));
+    expect(createProvider).toHaveLength(2);
   });
 
 
@@ -24,16 +23,15 @@ describe('createProvider', (): void => {
       });
 
       it('should be a React Component', (): void => {
-        expect(Object.getPrototypeOf(Provider))
-          .to.equal(Component);
+        expect(Object.getPrototypeOf(Provider)).toEqual(Component);
       });
 
       it('should have an empty state', (): void => {
-        expect(Provider.global).to.deep.equal({});
+        expect(Provider.global).toEqual({});
       });
 
       it('should have empty dispatchers', (): void => {
-        expect(Provider.dispatch).to.deep.equal({});
+        expect(Provider.dispatch).toEqual({});
       });
     });
 
@@ -47,16 +45,15 @@ describe('createProvider', (): void => {
       });
 
       it('should be a React Component', (): void => {
-        expect(Object.getPrototypeOf(Provider))
-          .to.equal(Component);
+        expect(Object.getPrototypeOf(Provider)).toEqual(Component);
       });
 
       it('should have a state', (): void => {
-        expect(Provider.global).to.deep.equal(INITIAL_STATE);
+        expect(Provider.global).toEqual(INITIAL_STATE);
       });
 
       it('should have empty dispatchers', (): void => {
-        expect(Provider.dispatch).to.deep.equal({});
+        expect(Provider.dispatch).toEqual({});
       });
     });
 
@@ -70,18 +67,17 @@ describe('createProvider', (): void => {
       });
 
       it('should be a React Component', (): void => {
-        expect(Object.getPrototypeOf(Provider))
-          .to.equal(Component);
+        expect(Object.getPrototypeOf(Provider)).toEqual(Component);
       });
 
       it('should have a state', (): void => {
-        expect(Provider.global).to.deep.equal(INITIAL_STATE);
+        expect(Provider.global).toEqual(INITIAL_STATE);
       });
 
       it('should have dispatchers', (): void => {
         const initialKeys = Object.keys(INITIAL_REDUCERS).sort();
         const setKeys = Object.keys(Provider.dispatch).sort();
-        expect(initialKeys).to.deep.equal(setKeys);
+        expect(initialKeys).toEqual(setKeys);
       });
     });
 

--- a/tests/decorator.test.ts
+++ b/tests/decorator.test.ts
@@ -1,16 +1,15 @@
-import { expect } from 'chai';
 import decorator from '../build/index';
 import commonjs = require('../build/index');
 
 describe('@reactn decorator', (): void => {
 
   it('should be the CommonJS export and the default export', (): void => {
-    expect(commonjs).to.equal(decorator);
+    expect(commonjs).toEqual(decorator);
   });
 
   it('should be a function with 1 argument', (): void => {
-    expect(decorator).to.be.a('function');
-    expect(decorator.length).to.equal(1);
+    expect(decorator).toEqual(expect.any(Function));
+    expect(decorator).toHaveLength(1);
   });
 
   it.skip('should do more', (): void => {

--- a/tests/default-global-state-manager.test.ts
+++ b/tests/default-global-state-manager.test.ts
@@ -1,18 +1,17 @@
-import { expect } from 'chai';
 import defaultGlobalStateManager from '../src/default-global-state-manager';
 import GlobalStateManager from '../src/global-state-manager';
 
 describe('Default GlobalStateManager', (): void => {
 
   it('should be a GlobalStateManager', (): void => {
-    expect(defaultGlobalStateManager).to.be.instanceOf(GlobalStateManager);
+    expect(defaultGlobalStateManager).toBeInstanceOf(GlobalStateManager);
   });
 
   it('should have an empty state', (): void => {
-    expect(defaultGlobalStateManager.state).to.deep.equal({});
+    expect(defaultGlobalStateManager.state).toEqual({});
   });
 
   it('should not have dispatchers', (): void => {
-    expect(defaultGlobalStateManager.dispatchers).to.deep.equal({});
+    expect(defaultGlobalStateManager.dispatchers).toEqual({});
   });
 });

--- a/tests/get-global.test.ts
+++ b/tests/get-global.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getGlobal from '../src/get-global';
 import GlobalStateManager from '../src/global-state-manager';
 import { GS, INITIAL_STATE } from './utils/initial';
@@ -18,18 +17,19 @@ describe('getGlobal', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(getGlobal).to.be.a('function');
-    expect(getGlobal.length).to.equal(1);
+    expect(getGlobal).toEqual(expect.any(Function));
+    expect(getGlobal).toHaveLength(1);
   });
 
   it('should call GlobalStateManager.state', (): void => {
     getGlobal(globalStateManager);
-    expect(spy.state.calledOnceWithExactly()).to.equal(true);
+    expect(spy.state).toHaveBeenCalledTimes(1);
+    expect(spy.state).toHaveBeenCalledWith();
   });
 
   it('should return a copy of the state', (): void => {
     const state: GS = getGlobal(globalStateManager);
-    expect(state).to.deep.equal(INITIAL_STATE);
-    expect(state).not.to.equal(INITIAL_STATE);
+    expect(state).toEqual(INITIAL_STATE);
+    expect(state).not.toBe(INITIAL_STATE);
   });
 });

--- a/tests/global-state-manager/add-callback.test.ts
+++ b/tests/global-state-manager/add-callback.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 import Callback from '../../src/typings/callback';
 
@@ -18,14 +17,14 @@ describe('GlobalStateManager.addCallback', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(globalStateManager.addCallback).to.be.a('function');
-    expect(globalStateManager.addCallback.length).to.equal(1);
+    expect(globalStateManager.addCallback).toEqual(expect.any(Function));
+    expect(globalStateManager.addCallback.length).toBe(1);
   });
 
   it('should add a callback', (): void => {
-    expect(globalStateManager.hasCallback(CALLBACK)).to.equal(false);
+    expect(globalStateManager.hasCallback(CALLBACK)).toBe(false);
     globalStateManager.addCallback(CALLBACK);
-    expect(globalStateManager.hasCallback(CALLBACK)).to.equal(true);
+    expect(globalStateManager.hasCallback(CALLBACK)).toBe(true);
   });
 
 
@@ -38,14 +37,14 @@ describe('GlobalStateManager.addCallback', (): void => {
     });
 
     it('should be a function with no arguments', (): void => {
-      expect(removeCallback).to.be.a('function');
-      expect(removeCallback.length).to.equal(0);
+      expect(removeCallback).toEqual(expect.any(Function));
+      expect(removeCallback.length).toBe(0);
     });
 
     it('should remove the callback', (): void => {
-      expect(globalStateManager.hasCallback(CALLBACK)).to.equal(true);
+      expect(globalStateManager.hasCallback(CALLBACK)).toBe(true);
       removeCallback();
-      expect(globalStateManager.hasCallback(CALLBACK)).to.equal(false);
+      expect(globalStateManager.hasCallback(CALLBACK)).toBe(false);
     });
   });
 

--- a/tests/global-state-manager/add-dispatcher.test.ts
+++ b/tests/global-state-manager/add-dispatcher.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 
 
@@ -19,14 +18,14 @@ describe('GlobalStateManager.addDispatcher', (): void => {
 
 
   it('should be a function with 2 arguments', (): void => {
-    expect(globalStateManager.addDispatcher).to.be.a('function');
-    expect(globalStateManager.addDispatcher.length).to.equal(2);
+    expect(globalStateManager.addDispatcher).toEqual(expect.any(Function));
+    expect(globalStateManager.addDispatcher.length).toBe(2);
   });
 
   it('should add a reducer', (): void => {
-    expect(globalStateManager.hasDispatcher(REDUCER_NAME)).to.equal(false);
+    expect(globalStateManager.hasDispatcher(REDUCER_NAME)).toBe(false);
     globalStateManager.addDispatcher(REDUCER_NAME, REDUCER);
-    expect(globalStateManager.hasDispatcher(REDUCER_NAME)).to.equal(true);
+    expect(globalStateManager.hasDispatcher(REDUCER_NAME)).toBe(true);
   });
 
 
@@ -39,14 +38,14 @@ describe('GlobalStateManager.addDispatcher', (): void => {
     });
 
     it('should be a function with no arguments', (): void => {
-      expect(removeDispatcher).to.be.a('function');
-      expect(removeDispatcher.length).to.equal(0);
+      expect(removeDispatcher).toEqual(expect.any(Function));
+      expect(removeDispatcher.length).toBe(0);
     });
 
     it('should remove the callback', (): void => {
-      expect(globalStateManager.hasDispatcher(REDUCER_NAME)).to.equal(true);
+      expect(globalStateManager.hasDispatcher(REDUCER_NAME)).toBe(true);
       removeDispatcher();
-      expect(globalStateManager.hasDispatcher(REDUCER_NAME)).to.equal(false);
+      expect(globalStateManager.hasDispatcher(REDUCER_NAME)).toBe(false);
     });
   });
 

--- a/tests/global-state-manager/add-property-listener.test.ts
+++ b/tests/global-state-manager/add-property-listener.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager, { PropertyListener } from '../../src/global-state-manager';
 
 
@@ -29,13 +28,13 @@ describe('GlobalStateManager.addPropertyListener', (): void => {
 
 
   it('should be a function with 2 arguments', (): void => {
-    expect(globalStateManager.addPropertyListener).to.be.a('function');
-    expect(globalStateManager.addPropertyListener.length).to.equal(2);
+    expect(globalStateManager.addPropertyListener).toEqual(expect.any(Function));;
+    expect(globalStateManager.addPropertyListener.length).toBe(2);
   });
 
   it('should not return anything', (): void => {
     expect(globalStateManager.addPropertyListener(PROPERTY, PROPERTY_LISTENER))
-      .to.be.undefined;
+      .toBeUndefined();
   });
 
 
@@ -44,16 +43,16 @@ describe('GlobalStateManager.addPropertyListener', (): void => {
 
     it('should add a property listener', (): void => {
       expect(globalStateManager.hasPropertyListener(PROPERTY_LISTENER))
-        .to.equal(false);
+        .toBe(false);
       globalStateManager.addPropertyListener(PROPERTY, PROPERTY_LISTENER);
       expect(globalStateManager.hasPropertyListener(PROPERTY_LISTENER))
-        .to.equal(true);
+        .toBe(true);
     });
 
     it('should not return anything', (): void => {
       const value: void =
         globalStateManager.addPropertyListener(PROPERTY, PROPERTY_LISTENER);
-      expect(value).to.be.undefined;
+      expect(value).toBeUndefined();
     });
   });
 
@@ -66,19 +65,19 @@ describe('GlobalStateManager.addPropertyListener', (): void => {
     it('should add a property listener', (): void => {
       globalStateManager.addPropertyListener(PROPERTY, PROPERTY_LISTENER);
       expect(globalStateManager.hasPropertyListener(PROPERTY_LISTENER))
-        .to.equal(true);
+        .toBe(true);
       expect(globalStateManager.hasPropertyListener(PROPERTY_LISTENER2))
-        .to.equal(false);
+        .toBe(false);
       globalStateManager.addPropertyListener(PROPERTY, PROPERTY_LISTENER2);
       expect(globalStateManager.hasPropertyListener(PROPERTY_LISTENER2))
-        .to.equal(true);
+        .toBe(true);
     });
 
     it('should not return anything', (): void => {
       globalStateManager.addPropertyListener(PROPERTY, PROPERTY_LISTENER);
       const value: void =
         globalStateManager.addPropertyListener(PROPERTY, PROPERTY_LISTENER2);
-      expect(value).to.be.undefined;
+      expect(value).toBeUndefined();
     });
   });
 

--- a/tests/global-state-manager/clear-queue.test.ts
+++ b/tests/global-state-manager/clear-queue.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 
 
@@ -23,18 +22,18 @@ describe('GlobalStateManager.clearQueue', (): void => {
 
 
   it('should be a function with no arguments', (): void => {
-    expect(globalStateManager.clearQueue).to.be.a('function');
-    expect(globalStateManager.clearQueue.length).to.equal(0);
+    expect(globalStateManager.clearQueue).toEqual(expect.any(Function));;
+    expect(globalStateManager.clearQueue.length).toBe(0);
   });
 
   it('should not return anything', (): void => {
-    expect(globalStateManager.clearQueue()).to.be.undefined;
+    expect(globalStateManager.clearQueue()).toBeUndefined();
   });
 
   it('should clear the queue', (): void => {
     globalStateManager.enqueue('x', true);
-    expect(globalStateManager.queue.size).to.equal(1);
+    expect(globalStateManager.queue.size).toBe(1);
     globalStateManager.clearQueue();
-    expect(globalStateManager.queue.size).to.equal(0);
+    expect(globalStateManager.queue.size).toBe(0);
   });
 });

--- a/tests/global-state-manager/constructor.test.ts
+++ b/tests/global-state-manager/constructor.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 import { GS, INITIAL_REDUCERS, INITIAL_STATE, R } from '../utils/initial';
 
@@ -8,24 +7,24 @@ describe('GlobalStateManager.constructor', (): void => {
 
   it('should initialize with an empty state object', (): void => {
     const globalStateManager: GlobalStateManager = new GlobalStateManager();
-    expect(globalStateManager.state).to.deep.equal({});
+    expect(globalStateManager.state).toEqual({});
   });
 
   it('should initialize with an empty dispatchers object', (): void => {
     const globalStateManager: GlobalStateManager = new GlobalStateManager();
-    expect(globalStateManager.dispatchers).to.deep.equal({});
+    expect(globalStateManager.dispatchers).toEqual({});
   });
 
   it('should support an initial state', (): void => {
     const globalStateManager: GlobalStateManager<GS> =
       new GlobalStateManager<GS>(INITIAL_STATE);
-    expect(globalStateManager.state).to.deep.equal(INITIAL_STATE);
+    expect(globalStateManager.state).toEqual(INITIAL_STATE);
   });
 
   it('should support initial dispatchers', (): void => {
     const globalStateManager: GlobalStateManager<GS, R> =
       new GlobalStateManager<GS, R>(INITIAL_STATE, INITIAL_REDUCERS);
     expect(Object.keys(globalStateManager.dispatchers))
-      .to.deep.equal(Object.keys(INITIAL_REDUCERS));
+      .toEqual(Object.keys(INITIAL_REDUCERS));
   });
 });

--- a/tests/global-state-manager/create-dispatcher.test.ts
+++ b/tests/global-state-manager/create-dispatcher.test.ts
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-import * as sinon from 'sinon';
 import GlobalStateManager from '../../src/global-state-manager';
 import { Dispatcher } from '../../src/typings/reducer';
 import { GS, INITIAL_REDUCERS, INITIAL_STATE } from '../utils/initial';
@@ -17,8 +15,8 @@ describe('GlobalStateManager.createDispatcher', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(globalStateManager.createDispatcher).to.be.a('function');
-    expect(globalStateManager.createDispatcher.length).to.equal(1);
+    expect(globalStateManager.createDispatcher).toEqual(expect.any(Function));;
+    expect(globalStateManager.createDispatcher.length).toBe(1);
   });
 
 
@@ -36,23 +34,20 @@ describe('GlobalStateManager.createDispatcher', (): void => {
     it('should be a function', (): void => {
       const dispatch: Dispatcher<typeof INITIAL_REDUCERS.reset> =
         globalStateManager.createDispatcher(INITIAL_REDUCERS.reset);
-      expect(dispatch).to.be.a('function');
+      expect(dispatch).toEqual(expect.any(Function));;
     });
 
     it('should auto-fill the global state argument', (): void => {
 
       const REDUCER_WITH_ARGS =
         (_gs: GS, _1: boolean, _2: number): null => null;
-      const spy: sinon.SinonSpy = sinon.spy(REDUCER_WITH_ARGS);
+      const spy = jest.fn(REDUCER_WITH_ARGS);
 
       const dispatch: Dispatcher<typeof REDUCER_WITH_ARGS> =
         globalStateManager.createDispatcher(spy);
       dispatch(true, 1);
-      expect(spy.calledOnce).to.equal(true);
-      expect(spy.args[0][0]).to.deep.equal(globalStateManager.state);
-      expect(spy.args[0][1]).to.equal(true);
-      expect(spy.args[0][2]).to.equal(1);
-      expect(spy.args[0][3]).to.be.undefined;
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(globalStateManager.state, true, 1);
     });
 
     const spy = spyOn('set');
@@ -64,7 +59,8 @@ describe('GlobalStateManager.createDispatcher', (): void => {
       const dispatch: Dispatcher<typeof REDUCER> =
         globalStateManager.createDispatcher(REDUCER);
       dispatch();
-      expect(spy.set.calledOnceWithExactly(NEW_STATE)).to.equal(true);
+      expect(spy.set).toHaveBeenCalledTimes(1);
+      expect(spy.set).toHaveBeenCalledWith(NEW_STATE);
     });
 
 
@@ -84,13 +80,13 @@ describe('GlobalStateManager.createDispatcher', (): void => {
 
       it('should be a Promise', async (): Promise<void> => {
         const value = dispatch();
-        expect(value).to.be.instanceOf(Promise);
+        expect(value).toBeInstanceOf(Promise);
         await value;
       });
 
       it('should resolve to the new global state', async (): Promise<void> => {
         const value: GS = await dispatch();
-        expect(value).to.deep.equal(globalStateManager.state);
+        expect(value).toEqual(globalStateManager.state);
       });
     });
 

--- a/tests/global-state-manager/enqueue.test.ts
+++ b/tests/global-state-manager/enqueue.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 import { GS, INITIAL_STATE } from '../utils/initial';
 
@@ -14,18 +13,18 @@ describe('GlobalStateManager.enqueue', (): void => {
 
 
   it('should be a function with 2 arguments', (): void => {
-    expect(globalStateManager.enqueue).to.be.a('function');
-    expect(globalStateManager.enqueue.length).to.equal(2);
+    expect(globalStateManager.enqueue).toEqual(expect.any(Function));;
+    expect(globalStateManager.enqueue.length).toBe(2);
   });
 
   it('should not return anything', (): void => {
-    expect(globalStateManager.enqueue('x', true)).to.be.undefined;
+    expect(globalStateManager.enqueue('x', true)).toBeUndefined();
   });
 
   it('should update the queue', (): void => {
-    expect(globalStateManager.queue.get('x')).to.be.undefined;
+    expect(globalStateManager.queue.get('x')).toBeUndefined();
     globalStateManager.enqueue('x', true);
-    expect(globalStateManager.queue.size).to.equal(1);
-    expect(globalStateManager.queue.get('x')).to.equal(true);
+    expect(globalStateManager.queue.size).toBe(1);
+    expect(globalStateManager.queue.get('x')).toBe(true);
   });
 });

--- a/tests/global-state-manager/flush.test.ts
+++ b/tests/global-state-manager/flush.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 import { GS, INITIAL_STATE } from '../utils/initial';
 
@@ -14,25 +13,25 @@ describe('GlobalStateManager.flush', (): void => {
 
 
   it('should be a function with no arguments', (): void => {
-    expect(globalStateManager.flush).to.be.a('function');
-    expect(globalStateManager.flush.length).to.equal(0);
+    expect(globalStateManager.flush).toEqual(expect.any(Function));;
+    expect(globalStateManager.flush.length).toBe(0);
   });
 
   it('should not return anything', (): void => {
-    expect(globalStateManager.flush()).to.be.undefined;
+    expect(globalStateManager.flush()).toBeUndefined();
   });
 
   it('should clear the queue', (): void => {
     globalStateManager.enqueue('x', true);
-    expect(globalStateManager.queue.size).to.equal(1);
+    expect(globalStateManager.queue.size).toBe(1);
     globalStateManager.flush();
-    expect(globalStateManager.queue.size).to.equal(0);
+    expect(globalStateManager.queue.size).toBe(0);
   });
 
   it('should write the queue to the state', (): void => {
-    expect(globalStateManager.state.x).to.equal(false);
+    expect(globalStateManager.state.x).toBe(false);
     globalStateManager.enqueue('x', true);
     globalStateManager.flush();
-    expect(globalStateManager.state.x).to.equal(true);
+    expect(globalStateManager.state.x).toBe(true);
   });
 });

--- a/tests/global-state-manager/remove-callback.test.ts
+++ b/tests/global-state-manager/remove-callback.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 
 
@@ -17,15 +16,15 @@ describe('GlobalStateManager.removeCallback', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(globalStateManager.removeCallback).to.be.a('function');
-    expect(globalStateManager.removeCallback.length).to.equal(1);
+    expect(globalStateManager.removeCallback).toEqual(expect.any(Function));;
+    expect(globalStateManager.removeCallback.length).toBe(1);
   });
 
   it('remove a callback', (): void => {
     globalStateManager.addCallback(CALLBACK);
-    expect(globalStateManager.hasCallback(CALLBACK)).to.equal(true);
+    expect(globalStateManager.hasCallback(CALLBACK)).toBe(true);
     globalStateManager.removeCallback(CALLBACK);
-    expect(globalStateManager.hasCallback(CALLBACK)).to.equal(false);
+    expect(globalStateManager.hasCallback(CALLBACK)).toBe(false);
   });
 
 
@@ -35,12 +34,12 @@ describe('GlobalStateManager.removeCallback', (): void => {
     it('should be true if the callback existed', (): void => {
       globalStateManager.addCallback(CALLBACK);
       const removed: boolean = globalStateManager.removeCallback(CALLBACK);
-      expect(removed).to.equal(true);
+      expect(removed).toBe(true);
     });
 
     it('should be false if the callback did not exist', (): void => {
       const removed: boolean = globalStateManager.removeCallback(CALLBACK);
-      expect(removed).to.equal(false);
+      expect(removed).toBe(false);
     });
   });
 

--- a/tests/global-state-manager/remove-dispatcher.test.ts
+++ b/tests/global-state-manager/remove-dispatcher.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 import { GS, INITIAL_REDUCERS, INITIAL_STATE, R } from '../utils/initial';
 
@@ -21,14 +20,14 @@ describe('GlobalStateManager.removeDispatcher', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(globalStateManager.removeDispatcher).to.be.a('function');
-    expect(globalStateManager.removeDispatcher.length).to.equal(1);
+    expect(globalStateManager.removeDispatcher).toEqual(expect.any(Function));;
+    expect(globalStateManager.removeDispatcher.length).toBe(1);
   });
 
   it('remove a dispatcher', (): void => {
-    expect(globalStateManager.hasDispatcher(DISPATCHER_NAME)).to.equal(true);
+    expect(globalStateManager.hasDispatcher(DISPATCHER_NAME)).toBe(true);
     globalStateManager.removeDispatcher(DISPATCHER_NAME);
-    expect(globalStateManager.hasDispatcher(DISPATCHER_NAME)).to.equal(false);
+    expect(globalStateManager.hasDispatcher(DISPATCHER_NAME)).toBe(false);
   });
 
 
@@ -38,14 +37,14 @@ describe('GlobalStateManager.removeDispatcher', (): void => {
     it('should be true if the dispatcher existed', (): void => {
       const removed: boolean =
         globalStateManager.removeDispatcher(DISPATCHER_NAME);
-      expect(removed).to.equal(true);
+      expect(removed).toBe(true);
     });
 
     it('should be false if the dispatcher did not exist', (): void => {
       const FAKE_DISPATCHER_NAME: string = 'mockDispatcher';
       const removed: boolean =
         globalStateManager.removeDispatcher(FAKE_DISPATCHER_NAME);
-      expect(removed).to.equal(false);
+      expect(removed).toBe(false);
     });
   });
 

--- a/tests/global-state-manager/remove-property-listener.test.ts
+++ b/tests/global-state-manager/remove-property-listener.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 import { GS, INITIAL_STATE } from '../utils/initial';
 
@@ -19,17 +18,17 @@ describe('GlobalStateManager.removePropertyListener', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(globalStateManager.removePropertyListener).to.be.a('function');
-    expect(globalStateManager.removePropertyListener.length).to.equal(1);
+    expect(globalStateManager.removePropertyListener).toEqual(expect.any(Function));;
+    expect(globalStateManager.removePropertyListener.length).toBe(1);
   });
 
   it('remove a property listener', (): void => {
     globalStateManager.addPropertyListener(PROPERTY, PROPERTY_LISTENER);
     expect(globalStateManager.hasPropertyListener(PROPERTY_LISTENER))
-      .to.equal(true);
+      .toBe(true);
     globalStateManager.removePropertyListener(PROPERTY_LISTENER);
     expect(globalStateManager.hasPropertyListener(PROPERTY_LISTENER))
-      .to.equal(false);
+      .toBe(false);
   });
 
 
@@ -40,13 +39,13 @@ describe('GlobalStateManager.removePropertyListener', (): void => {
       globalStateManager.addPropertyListener(PROPERTY, PROPERTY_LISTENER);
       const removed: boolean =
         globalStateManager.removePropertyListener(PROPERTY_LISTENER);
-      expect(removed).to.equal(true);
+      expect(removed).toBe(true);
     });
 
     it('should be false if the property listener did not exist', (): void => {
       const removed: boolean =
         globalStateManager.removePropertyListener(PROPERTY_LISTENER);
-      expect(removed).to.equal(false);
+      expect(removed).toBe(false);
     });
   });
 

--- a/tests/global-state-manager/reset.test.ts
+++ b/tests/global-state-manager/reset.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 import { GS, INITIAL_REDUCERS, INITIAL_STATE, R } from '../utils/initial';
 
@@ -17,16 +16,16 @@ describe('GlobalStateManager.reset', (): void => {
 
 
   it('should be a function with no arguments', (): void => {
-    expect(globalStateManager.reset).to.be.a('function');
-    expect(globalStateManager.reset.length).to.equal(0);
+    expect(globalStateManager.reset).toEqual(expect.any(Function));;
+    expect(globalStateManager.reset.length).toBe(0);
   });
 
   it('should remove callbacks', (): void => {
     const CALLBACK = (): void => { };
     globalStateManager.addCallback(CALLBACK);
-    expect(globalStateManager.hasCallback(CALLBACK)).to.equal(true);
+    expect(globalStateManager.hasCallback(CALLBACK)).toBe(true);
     globalStateManager.reset();
-    expect(globalStateManager.hasCallback(CALLBACK)).to.equal(false);
+    expect(globalStateManager.hasCallback(CALLBACK)).toBe(false);
   });
 
   it('should reset dispatchers', (): void => {
@@ -34,11 +33,11 @@ describe('GlobalStateManager.reset', (): void => {
     const REDUCER_NAME = 'reducerName';
 
     globalStateManager.addDispatcher(REDUCER_NAME, REDUCER);
-    expect(globalStateManager.hasDispatcher('increment')).to.equal(true);
-    expect(globalStateManager.hasDispatcher(REDUCER_NAME)).to.equal(true);
+    expect(globalStateManager.hasDispatcher('increment')).toBe(true);
+    expect(globalStateManager.hasDispatcher(REDUCER_NAME)).toBe(true);
     globalStateManager.reset();
-    expect(globalStateManager.hasDispatcher('increment')).to.equal(true);
-    expect(globalStateManager.hasDispatcher(REDUCER_NAME)).to.equal(false);
+    expect(globalStateManager.hasDispatcher('increment')).toBe(true);
+    expect(globalStateManager.hasDispatcher(REDUCER_NAME)).toBe(false);
   });
 
   it('should remove property listeners', (): void => {
@@ -46,17 +45,17 @@ describe('GlobalStateManager.reset', (): void => {
     const PROPERTY_LISTENER = (): void => { };
     globalStateManager.addPropertyListener(PROPERTY, PROPERTY_LISTENER);
     expect(globalStateManager.hasPropertyListener(PROPERTY_LISTENER))
-      .to.equal(true);
+      .toBe(true);
     globalStateManager.reset();
     expect(globalStateManager.hasPropertyListener(PROPERTY_LISTENER))
-      .to.equal(false);
+      .toBe(false);
   });
 
   it('should empty the queue', (): void => {
     globalStateManager.enqueue('x', true);
-    expect(globalStateManager.queue.size).to.equal(1);
+    expect(globalStateManager.queue.size).toBe(1);
     globalStateManager.reset();
-    expect(globalStateManager.queue.size).to.equal(0);
+    expect(globalStateManager.queue.size).toBe(0);
   });
 
   it('should reset the state', async (): Promise<void> => {
@@ -65,12 +64,12 @@ describe('GlobalStateManager.reset', (): void => {
       y: 1,
       z: 'any',
     });
-    expect(globalStateManager.state).not.to.deep.equal(INITIAL_STATE);
+    expect(globalStateManager.state).not.toEqual(INITIAL_STATE);
     globalStateManager.reset();
-    expect(globalStateManager.state).to.deep.equal(INITIAL_STATE);
+    expect(globalStateManager.state).toEqual(INITIAL_STATE);
   });
 
   it('should not return anything', (): void => {
-    expect(globalStateManager.reset()).to.be.undefined;
+    expect(globalStateManager.reset()).toBeUndefined();
   });
 });

--- a/tests/global-state-manager/set-function.test.ts
+++ b/tests/global-state-manager/set-function.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 import { GS, INITIAL_STATE } from '../utils/initial';
 import spyOn from '../utils/spy-on-global-state-manager';
@@ -24,13 +23,14 @@ describe('GlobalStateManager.setFunction', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(globalStateManager.setFunction).to.be.a('function');
-    expect(globalStateManager.setFunction.length).to.equal(1);
+    expect(globalStateManager.setFunction).toEqual(expect.any(Function));;
+    expect(globalStateManager.setFunction.length).toBe(1);
   });
 
   it('should call set', async (): Promise<void> => {
     const set: Promise<GS> = globalStateManager.setFunction(FUNC);
-    expect(spy.set.calledOnceWithExactly(STATE_CHANGE)).to.equal(true);
+    expect(spy.set).toHaveBeenCalledTimes(1);
+    expect(spy.set).toHaveBeenCalledWith(STATE_CHANGE);
     await set;
   });
 
@@ -40,14 +40,14 @@ describe('GlobalStateManager.setFunction', (): void => {
 
     it('should be a Promise', async (): Promise<void> => {
       const set: Promise<GS | void> = globalStateManager.setFunction(FUNC);
-      expect(set).to.be.instanceOf(Promise);
+      expect(set).toBeInstanceOf(Promise);
       await set;
     });
 
     it('should resolve to the new global state', async (): Promise<void> => {
       const set: Promise<GS> = globalStateManager.setFunction(FUNC);
       const value = await set;
-      expect(value).to.deep.equal({
+      expect(value).toEqual({
         ...INITIAL_STATE,
         ...STATE_CHANGE,
       });

--- a/tests/global-state-manager/set-object.test.ts
+++ b/tests/global-state-manager/set-object.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 import { GS, INITIAL_STATE } from '../utils/initial';
 import spyOn from '../utils/spy-on-global-state-manager';
@@ -22,15 +21,17 @@ describe('GlobalStateManager.setObject', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(globalStateManager.setObject).to.be.a('function');
-    expect(globalStateManager.setObject.length).to.equal(1);
+    expect(globalStateManager.setObject).toEqual(expect.any(Function));;
+    expect(globalStateManager.setObject.length).toBe(1);
   });
 
   it('should call enqueue and flush', async (): Promise<void> => {
     await globalStateManager.setObject(STATE_CHANGE);
-    expect(spy.enqueue.calledOnceWithExactly('x', STATE_CHANGE.x))
-      .to.equal(true);
-    expect(spy.flush.calledOnceWithExactly()).to.equal(true);
+    expect(spy.enqueue).toHaveBeenCalledTimes(1);
+    expect(spy.enqueue).toHaveBeenCalledWith('x', STATE_CHANGE.x);
+
+    expect(spy.flush).toHaveBeenCalledTimes(1);
+    expect(spy.flush).toHaveBeenCalledWith();
   });
 
 
@@ -40,14 +41,14 @@ describe('GlobalStateManager.setObject', (): void => {
     it('should be a Promise', async (): Promise<void> => {
       const set: Promise<GS | void> =
         globalStateManager.setObject(STATE_CHANGE);
-      expect(set).to.be.instanceOf(Promise);
+      expect(set).toBeInstanceOf(Promise);
       await set;
     });
 
     it('should resolve to the new global state', async (): Promise<void> => {
       const set: Promise<GS> = globalStateManager.setObject(STATE_CHANGE);
       const value = await set;
-      expect(value).to.deep.equal({
+      expect(value).toEqual({
         ...INITIAL_STATE,
         ...STATE_CHANGE,
       });

--- a/tests/global-state-manager/set-promise.test.ts
+++ b/tests/global-state-manager/set-promise.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 import { GS, INITIAL_STATE } from '../utils/initial';
 import spyOn from '../utils/spy-on-global-state-manager';
@@ -24,13 +23,14 @@ describe('GlobalStateManager.setPromise', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(globalStateManager.setPromise).to.be.a('function');
-    expect(globalStateManager.setPromise.length).to.equal(1);
+    expect(globalStateManager.setPromise).toEqual(expect.any(Function));;
+    expect(globalStateManager.setPromise.length).toBe(1);
   });
 
   it('should call set', async (): Promise<void> => {
     await globalStateManager.setPromise(PROMISE);
-    expect(spy.set.calledOnceWithExactly(STATE_CHANGE)).to.equal(true);
+    expect(spy.set).toHaveBeenCalledTimes(1);
+    expect(spy.set).toHaveBeenCalledWith(STATE_CHANGE);
   });
 
 
@@ -39,14 +39,14 @@ describe('GlobalStateManager.setPromise', (): void => {
 
     it('should be a Promise', async (): Promise<void> => {
       const set: Promise<GS | void> = globalStateManager.setPromise(PROMISE);
-      expect(set).to.be.instanceOf(Promise);
+      expect(set).toBeInstanceOf(Promise);
       await set;
     });
 
     it('should resolve to the new global state', async (): Promise<void> => {
       const set: Promise<GS> = globalStateManager.setPromise(PROMISE);
       const value = await set;
-      expect(value).to.deep.equal({
+      expect(value).toEqual({
         ...INITIAL_STATE,
         ...STATE_CHANGE,
       });

--- a/tests/global-state-manager/set.test.ts
+++ b/tests/global-state-manager/set.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager, {
   INVALID_NEW_GLOBAL_STATE,
 } from '../../src/global-state-manager';
@@ -25,29 +24,29 @@ describe('GlobalStateManager.set', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(globalStateManager.set).to.be.a('function');
-    expect(globalStateManager.set.length).to.equal(1);
+    expect(globalStateManager.set).toEqual(expect.any(Function));;
+    expect(globalStateManager.set.length).toBe(1);
   });
 
   it('should not accept boolean', (): void => {
     expect((): void => {
       // @ts-ignore: Deliberately throwing an error.
       globalStateManager.set(true);
-    }).to.throw(INVALID_NEW_GLOBAL_STATE);
+    }).toThrow(INVALID_NEW_GLOBAL_STATE);
   });
 
   it('should not accept number', (): void => {
     expect((): void => {
       // @ts-ignore: Deliberately throwing an error.
       globalStateManager.set(1);
-    }).to.throw(INVALID_NEW_GLOBAL_STATE);
+    }).toThrow(INVALID_NEW_GLOBAL_STATE);
   });
 
   it('should not accept string', (): void => {
     expect((): void => {
       // @ts-ignore: Deliberately throwing an error.
       globalStateManager.set('any');
-    }).to.throw(INVALID_NEW_GLOBAL_STATE);
+    }).toThrow(INVALID_NEW_GLOBAL_STATE);
   });
 
   it(
@@ -55,7 +54,8 @@ describe('GlobalStateManager.set', (): void => {
     async (): Promise<void> => {
       const FUNC = (): null => null;
       const set: Promise<GS> = globalStateManager.set(FUNC);
-      expect(spy.setFunction.calledOnceWithExactly(FUNC)).to.equal(true);
+      expect(spy.setFunction).toHaveBeenCalledTimes(1);
+      expect(spy.setFunction).toHaveBeenCalledWith(FUNC);
       await set;
     }
   );
@@ -67,7 +67,8 @@ describe('GlobalStateManager.set', (): void => {
         x: true,
       };
       const set: Promise<GS> = globalStateManager.set(OBJ);
-      expect(spy.setObject.calledOnceWithExactly(OBJ)).to.equal(true);
+      expect(spy.setObject).toHaveBeenCalledTimes(1);
+      expect(spy.setObject).toHaveBeenCalledWith(OBJ);
       await set;
     }
   );
@@ -79,7 +80,8 @@ describe('GlobalStateManager.set', (): void => {
         x: true,
       });
       const set: Promise<GS> = globalStateManager.set(PROMISE);
-      expect(spy.setPromise.calledOnceWithExactly(PROMISE)).to.equal(true);
+      expect(spy.setPromise).toHaveBeenCalledTimes(1);
+      expect(spy.setPromise).toHaveBeenCalledWith(PROMISE);
       await set;
     }
   );
@@ -90,9 +92,9 @@ describe('GlobalStateManager.set', (): void => {
 
     it('should exist if the new state is null', async (): Promise<void> => {
       const set: Promise<GS> = globalStateManager.set(null);
-      expect(set).to.be.instanceOf(Promise);
+      expect(set).toBeInstanceOf(Promise);
       const globalState: GS = await set;
-      expect(globalState).to.deep.equal(INITIAL_STATE);
+      expect(globalState).toEqual(INITIAL_STATE);
     });
 
     it(
@@ -102,9 +104,9 @@ describe('GlobalStateManager.set', (): void => {
           x: true,
         });
         const set: Promise<GS> = globalStateManager.set(FUNC);
-        expect(set).to.be.instanceOf(Promise);
+        expect(set).toBeInstanceOf(Promise);
         const globalState: GS = await set;
-        expect(globalState).to.deep.equal(NEW_STATE);
+        expect(globalState).toEqual(NEW_STATE);
       }
     );
 
@@ -114,9 +116,9 @@ describe('GlobalStateManager.set', (): void => {
         const set: Promise<GS> = globalStateManager.set({
           x: true,
         });
-        expect(set).to.be.instanceOf(Promise);
+        expect(set).toBeInstanceOf(Promise);
         const globalState: GS = await set;
-        expect(globalState).to.deep.equal(NEW_STATE);
+        expect(globalState).toEqual(NEW_STATE);
       }
     );
 
@@ -126,9 +128,9 @@ describe('GlobalStateManager.set', (): void => {
         const set: Promise<GS> = globalStateManager.set(Promise.resolve({
           x: true,
         }));
-        expect(set).to.be.instanceOf(Promise);
+        expect(set).toBeInstanceOf(Promise);
         const globalState: GS = await set;
-        expect(globalState).to.deep.equal(NEW_STATE);
+        expect(globalState).toEqual(NEW_STATE);
       }
     );
   });

--- a/tests/global-state-manager/spy-state.test.ts
+++ b/tests/global-state-manager/spy-state.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../../src/global-state-manager';
 import { GS, INITIAL_STATE } from '../utils/initial';
 import spyOn from '../utils/spy-on-global-state-manager';
@@ -27,13 +26,13 @@ describe('GlobalStateManager.spyState', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(globalStateManager.spyState).to.be.a('function');
-    expect(globalStateManager.spyState.length).to.equal(1);
+    expect(globalStateManager.spyState).toEqual(expect.any(Function));;
+    expect(globalStateManager.spyState.length).toBe(1);
   });
 
   it('should return the current state', async (): Promise<void> => {
     await globalStateManager.set(MOCK_STATE);
-    expect(globalStateManager.spyState(PROPERTY_LISTENER)).to.deep.equal({
+    expect(globalStateManager.spyState(PROPERTY_LISTENER)).toEqual({
       ...INITIAL_STATE,
       ...MOCK_STATE,
     });
@@ -41,11 +40,9 @@ describe('GlobalStateManager.spyState', (): void => {
 
   it('should add a property listener when accessed', (): void => {
     expect(globalStateManager.hasPropertyListener(PROPERTY_LISTENER))
-      .to.equal(false);
+      .toBe(false);
     globalStateManager.spyState(PROPERTY_LISTENER)[PROPERTY];
-    expect(spy.addPropertyListener.calledOnceWithExactly(
-      PROPERTY,
-      PROPERTY_LISTENER,
-    )).to.equal(true);
+    expect(spy.addPropertyListener).toHaveBeenCalledTimes(1);
+    expect(spy.addPropertyListener).toHaveBeenCalledWith(PROPERTY, PROPERTY_LISTENER);
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import React = require('react');
 import ReactN from '../build/index';
 const reactn = require('../build/index');
@@ -15,9 +14,9 @@ const overrides: Set<string> = new Set([
 describe('package.json main', (): void => {
 
   it('should support import or require', (): void => {
-    expect(reactn).to.equal(ReactN);
-    expect(reactn.default).to.equal(ReactN);
-    expect(reactn).to.equal(ReactN.default);
+    expect(reactn).toBe(ReactN);
+    expect(reactn.default).toBe(ReactN);
+    expect(reactn).toBe(ReactN.default);
   });
 
   it('should extend React', (): void => {
@@ -29,91 +28,91 @@ describe('package.json main', (): void => {
 
     // All remaining properties should match React.
     for (const [ key, value ] of entries) {
-      expect(ReactN[key]).to.equal(value);
+      expect(ReactN[key]).toEqual(value);
     }
   });
 
   it('should override some React values', (): void => {
     for (const override of overrides) {
-      expect(ReactN[override]).not.to.equal(React[override]);
+      expect(ReactN[override]).not.toEqual(React[override]);
     }
   });
 
   // addCallback
   it('should contain addCallback', (): void => {
-    expect(ReactN.addCallback).to.be.a('function');
-    expect(ReactN.addCallback.length).to.equal(1);
+    expect(ReactN.addCallback).toEqual(expect.any(Function));
+    expect(ReactN.addCallback.length).toBe(1);
   });
 
   // addReducer
   it('should contain addReducer', (): void => {
-    expect(ReactN.addReducer).to.be.a('function');
-    expect(ReactN.addReducer.length).to.equal(2);
+    expect(ReactN.addReducer).toEqual(expect.any(Function));
+    expect(ReactN.addReducer.length).toBe(2);
   });
 
   // addReducers
   it('should contain addReducers', (): void => {
-    expect(ReactN.addReducers).to.be.a('function');
-    expect(ReactN.addReducers.length).to.equal(1);
+    expect(ReactN.addReducers).toEqual(expect.any(Function));
+    expect(ReactN.addReducers.length).toBe(1);
   });
 
   // Component
   it('should contain the ReactN Component class', (): void => {
-    expect(ReactN.Component).to.be.a('function');
+    expect(ReactN.Component).toEqual(expect.any(Function));
   });
 
   // createProvider
   it('should contain createProvider', (): void => {
-    expect(ReactN.createProvider).to.be.a('function');
-    expect(ReactN.createProvider.length).to.equal(2);
+    expect(ReactN.createProvider).toEqual(expect.any(Function));
+    expect(ReactN.createProvider.length).toBe(2);
   });
 
   // default
   it('should contain the @reactn decorator', (): void => {
-    expect(ReactN).to.be.a('function');
-    expect(ReactN.default).to.be.a('function');
-    expect(ReactN).to.equal(ReactN.default);
+    expect(ReactN).toEqual(expect.any(Function));
+    expect(ReactN.default).toEqual(expect.any(Function));
+    expect(ReactN).toBe(ReactN.default);
   });
 
   // getGlobal
   it('should contain getGlobal', (): void => {
-    expect(ReactN.getGlobal).to.be.a('function');
-    expect(ReactN.getGlobal.length).to.equal(0);
+    expect(ReactN.getGlobal).toEqual(expect.any(Function));
+    expect(ReactN.getGlobal).toHaveLength(0);
   });
 
   // PureComponent
   it('should contain the ReactN PureComponent class', (): void => {
-    expect(ReactN.PureComponent).to.be.a('function');
+    expect(ReactN.PureComponent).toEqual(expect.any(Function));
   });
 
   // removeCallback
   it('should contain removeCallback', (): void => {
-    expect(ReactN.removeCallback).to.be.a('function');
-    expect(ReactN.removeCallback.length).to.equal(1);
+    expect(ReactN.removeCallback).toEqual(expect.any(Function));
+    expect(ReactN.removeCallback).toHaveLength(1);
   });
 
   // resetGlobal
   it('should contain resetGlobal', (): void => {
-    expect(ReactN.resetGlobal).to.be.a('function');
-    expect(ReactN.resetGlobal.length).to.equal(0);
+    expect(ReactN.resetGlobal).toEqual(expect.any(Function));
+    expect(ReactN.resetGlobal).toHaveLength(0);
   });
 
   // setGlobal
   it('should contain setGlobal', (): void => {
-    expect(ReactN.setGlobal).to.be.a('function');
-    expect(ReactN.setGlobal.length).to.equal(2);
+    expect(ReactN.setGlobal).toEqual(expect.any(Function));
+    expect(ReactN.setGlobal).toHaveLength(2);
   });
 
   // useGlobal
   it('should contain useGlobal', (): void => {
-    expect(ReactN.useGlobal).to.be.a('function');
-    expect(ReactN.useGlobal.length).to.equal(2);
+    expect(ReactN.useGlobal).toEqual(expect.any(Function));
+    expect(ReactN.useGlobal).toHaveLength(2);
   });
 
   // withGlobal
   it('should contain withGlobal', (): void => {
-    expect(ReactN.withGlobal).to.be.a('function');
-    expect(ReactN.withGlobal.length).to.equal(2);
+    expect(ReactN.withGlobal).toEqual(expect.any(Function));
+    expect(ReactN.withGlobal).toHaveLength(2);
   });
 
 });

--- a/tests/make-iterable.test.ts
+++ b/tests/make-iterable.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import makeIterable from '../src/utils/make-iterable';
 
 describe('makeIterable', (): void => {
@@ -8,10 +7,10 @@ describe('makeIterable', (): void => {
     makeIterable(x, 1, 'ABC', true, x);
     // @ts-ignore: () => { } is not an array
     const [ num, str, bool, f ] = x;
-    expect(num).to.equal(1);
-    expect(str).to.equal('ABC');
-    expect(bool).to.equal(true);
-    expect(f).to.equal(x);
+    expect(num).toBe(1);
+    expect(str).toBe('ABC');
+    expect(bool).toBe(true);
+    expect(f).toBe(x);
   });
 
   it('should make a function iterable', (): void => {
@@ -20,7 +19,7 @@ describe('makeIterable', (): void => {
     const y = makeIterable.apply(null, [ x, ...items ]);
     let key = 0;
     for (const item of y) {
-      expect(item).to.equal(items[key]);
+      expect(item).toBe(items[key]);
       key++;
     }
   });

--- a/tests/object-get-listener.test.ts
+++ b/tests/object-get-listener.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import objectGetListener from '../src/utils/object-get-listener';
 
 interface Shape {
@@ -20,7 +19,7 @@ describe('objectGetListener', (): void => {
     const obj2 = objectGetListener(obj1, (): void => { });
 
     // Expect the shape to be the same.
-    expect(obj1).to.deep.equal(obj2);
+    expect(obj1).toEqual(obj2);
   });
 
   it('should subscribe to the object properties\' get', (): void => {
@@ -38,11 +37,11 @@ describe('objectGetListener', (): void => {
       z: 3,
     };
     const obj2 = objectGetListener(obj, listener);
-    expect(obj2.y).to.equal(2);
+    expect(obj2.y).toBe(2);
 
     // Expect only Y to be read.
-    expect(read.has('x')).to.equal(false);
-    expect(read.has('y')).to.equal(true);
-    expect(read.has('z')).to.equal(false);
+    expect(read.has('x')).toBe(false);
+    expect(read.has('y')).toBe(true);
+    expect(read.has('z')).toBe(false);
   });
 });

--- a/tests/provider/add-callback.test.ts
+++ b/tests/provider/add-callback.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import createProvider, { ReactNProvider } from '../../src/create-provider';
 import spyOn from '../utils/spy-on-global-state-manager';
 
@@ -18,13 +17,14 @@ describe('Provider.addCallback', (): void => {
   });
 
   it('should be a function with 1 argument', (): void => {
-    expect(Provider.addCallback).to.be.a('function');
-    expect(Provider.addCallback.length).to.equal(1);
+    expect(Provider.addCallback).toEqual(expect.any(Function));;
+    expect(Provider.addCallback.length).toBe(1);
   });
 
   it('should call GlobalStateManager.addCallback', (): void => {
     Provider.addCallback(CALLBACK);
-    expect(spy.addCallback.calledOnceWithExactly(CALLBACK)).to.equal(true);
+    expect(spy.addCallback).toHaveBeenCalledTimes(1);
+    expect(spy.addCallback).toHaveBeenCalledWith(CALLBACK);
   });
 
   describe('return value', (): void => {
@@ -36,18 +36,18 @@ describe('Provider.addCallback', (): void => {
     });
 
     it('should be a function with no arguments', (): void => {
-      expect(removeCallback).to.be.a('function');
-      expect(removeCallback.length).to.equal(0);
+      expect(removeCallback).toEqual(expect.any(Function));;
+      expect(removeCallback.length).toBe(0);
     });
 
     it('should call GlobalStateManager.removeCallback', (): void => {
       removeCallback();
-      expect(spy.removeCallback.calledOnceWithExactly(CALLBACK))
-        .to.equal(true);
+      expect(spy.removeCallback).toHaveBeenCalledTimes(1);
+      expect(spy.removeCallback).toHaveBeenCalledWith(CALLBACK);
     });
 
     it('should return true', (): void => {
-      expect(removeCallback()).to.equal(true);
+      expect(removeCallback()).toBe(true);
     });
   });
 });

--- a/tests/provider/add-reducer.test.ts
+++ b/tests/provider/add-reducer.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import createProvider, { ReactNProvider } from '../../src/create-provider';
 import spyOn from '../utils/spy-on-global-state-manager';
 
@@ -22,14 +21,14 @@ describe('Provider.addReducer', (): void => {
 
 
   it('should be a function with 2 arguments', (): void => {
-    expect(Provider.addReducer).to.be.a('function');
-    expect(Provider.addReducer.length).to.equal(2);
+    expect(Provider.addReducer).toEqual(expect.any(Function));;
+    expect(Provider.addReducer.length).toBe(2);
   });
 
   it('should call GlobalStateManager.addDispatcher', (): void => {
     Provider.addReducer(REDUCER_NAME, REDUCER);
-    expect(spy.addDispatcher.calledOnceWithExactly(REDUCER_NAME, REDUCER))
-      .to.equal(true);
+    expect(spy.addDispatcher).toHaveBeenCalledTimes(1);
+    expect(spy.addDispatcher).toHaveBeenCalledWith(REDUCER_NAME, REDUCER);
   });
 
 
@@ -42,18 +41,18 @@ describe('Provider.addReducer', (): void => {
     });
 
     it('should be a function with no arguments', (): void => {
-      expect(removeReducer).to.be.a('function');
-      expect(removeReducer.length).to.equal(0);
+      expect(removeReducer).toEqual(expect.any(Function));;
+      expect(removeReducer.length).toBe(0);
     });
 
     it('should call GlobalStateManager.removeDispatcher', (): void => {
       removeReducer();
-      expect(spy.removeDispatcher.calledOnceWithExactly(REDUCER_NAME))
-        .to.equal(true);
+      expect(spy.removeDispatcher).toHaveBeenCalledTimes(1);
+      expect(spy.removeDispatcher).toHaveBeenCalledWith(REDUCER_NAME);
     });
 
     it('should return true', (): void => {
-      expect(removeReducer()).to.equal(true);
+      expect(removeReducer()).toBe(true);
     });
   });
 

--- a/tests/provider/add-reducers.test.ts
+++ b/tests/provider/add-reducers.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import createProvider, { ReactNProvider } from '../../src/create-provider';
 import Reducer from '../../src/typings/reducer';
 import { GS, INITIAL_REDUCERS, INITIAL_STATE } from '../utils/initial';
@@ -24,18 +23,17 @@ describe('Provider.addReducers', (): void => {
 
 
   it('should be a function with 1 arguments', (): void => {
-    expect(Provider.addReducers).to.be.a('function');
-    expect(Provider.addReducers.length).to.equal(1);
+    expect(Provider.addReducers).toEqual(expect.any(Function));;
+    expect(Provider.addReducers.length).toBe(1);
   });
 
   it(
     'should call GlobalStateManager.addDispatcher for each reducer',
     (): void => {
       Provider.addReducers(INITIAL_REDUCERS);
-      expect(spy.addDispatcher.callCount).to.equal(REDUCERS.length);
+      expect(spy.addDispatcher).toHaveBeenCalledTimes(REDUCERS.length);
       for (const [ name, reducer ] of REDUCERS) {
-        expect(spy.addDispatcher.calledWithExactly(name, reducer))
-          .to.equal(true);
+        expect(spy.addDispatcher).toHaveBeenCalledWith(name, reducer);
       }
     }
   );
@@ -52,24 +50,23 @@ describe('Provider.addReducers', (): void => {
 
 
     it('should be a function with no arguments', (): void => {
-      expect(removeReducers).to.be.a('function');
-      expect(removeReducers.length).to.equal(0);
+      expect(removeReducers).toEqual(expect.any(Function));;
+      expect(removeReducers.length).toBe(0);
     });
 
     it(
       'should call GlobalStateManager.removeDispatcher for each reducer',
       (): void => {
         removeReducers();
-        expect(spy.removeDispatcher.callCount).to.equal(REDUCER_NAMES.length);
+        expect(spy.removeDispatcher).toHaveBeenCalledTimes(REDUCER_NAMES.length);
         for (const reducerName of REDUCER_NAMES) {
-          expect(spy.removeDispatcher.calledWithExactly(reducerName))
-            .to.equal(true);
+          expect(spy.removeDispatcher).toHaveBeenCalledWith(reducerName);
         }
       }
     );
 
     it('should return true', (): void => {
-      expect(removeReducers()).to.equal(true);
+      expect(removeReducers()).toBe(true);
     });
   });
 

--- a/tests/provider/dispatch.test.ts
+++ b/tests/provider/dispatch.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import createProvider, { ReactNProvider } from '../../src/create-provider';
 import { GS, INITIAL_REDUCERS, INITIAL_STATE, R } from '../utils/initial';
 
@@ -14,9 +13,9 @@ describe('Provider.dispatch', (): void => {
 
 
   it('should be an object of functions', (): void => {
-    expect(Provider.dispatch).to.be.an('object');
+    expect(Provider.dispatch).toEqual(expect.any(Object));
     for (const dispatcher of Object.values(Provider.dispatch)) {
-      expect(dispatcher).to.be.a('function');
+      expect(dispatcher).toEqual(expect.any(Function));;
     }
   });
 
@@ -24,21 +23,21 @@ describe('Provider.dispatch', (): void => {
     expect((): void => {
       // @ts-ignore: Deliberately throwing an error.
       Provider.dispatch = true;
-    }).to.throw();
+    }).toThrow();
   });
 
   it('should share keys with reducers', (): void => {
     const dispatchKeys = Object.keys(Provider.dispatch).sort();
     const reducerKeys = Object.keys(INITIAL_REDUCERS).sort();
-    expect(dispatchKeys).to.deep.equal(reducerKeys);
+    expect(dispatchKeys).toEqual(reducerKeys);
   });
 
   it('should update when reducers update', (): void => {
     const REDUCER = (): void => {};
     const REDUCER_NAME = 'REDUCER_NAME';
 
-    expect(Provider.dispatch[REDUCER_NAME]).to.be.undefined;
+    expect(Provider.dispatch[REDUCER_NAME]).toBeUndefined();
     Provider.addReducer(REDUCER_NAME, REDUCER);
-    expect(Provider.dispatch[REDUCER_NAME]).to.be.a('function');
+    expect(Provider.dispatch[REDUCER_NAME]).toEqual(expect.any(Function));;
   });
 });

--- a/tests/provider/get-dispatch.test.ts
+++ b/tests/provider/get-dispatch.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import createProvider, { ReactNProvider } from '../../src/create-provider';
 import { GS, INITIAL_REDUCERS, INITIAL_STATE, R } from '../utils/initial';
 
@@ -14,11 +13,11 @@ describe('Provider.getDispatch', (): void => {
 
 
   it('should be a function with no arguments', (): void => {
-    expect(Provider.getDispatch).to.be.a('function');
-    expect(Provider.getDispatch.length).to.equal(0);
+    expect(Provider.getDispatch).toEqual(expect.any(Function));;
+    expect(Provider.getDispatch.length).toBe(0);
   });
 
   it('should return dispatch', (): void => {
-    expect(Provider.getDispatch()).to.deep.equal(Provider.dispatch);
+    expect(Provider.getDispatch()).toEqual(Provider.dispatch);
   });
 });

--- a/tests/provider/get-global.test.ts
+++ b/tests/provider/get-global.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import createProvider, { ReactNProvider } from '../../src/create-provider';
 import { GS, INITIAL_STATE } from '../utils/initial';
 
@@ -14,11 +13,11 @@ describe('Provider.getGlobal', (): void => {
 
 
   it('should be a function with no arguments', (): void => {
-    expect(Provider.getGlobal).to.be.a('function');
-    expect(Provider.getGlobal.length).to.equal(0);
+    expect(Provider.getGlobal).toEqual(expect.any(Function));;
+    expect(Provider.getGlobal.length).toBe(0);
   });
 
   it('should return global', (): void => {
-    expect(Provider.getGlobal()).to.deep.equal(Provider.global);
+    expect(Provider.getGlobal()).toEqual(Provider.global);
   });
 });

--- a/tests/provider/global.test.ts
+++ b/tests/provider/global.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import createProvider, { ReactNProvider } from '../../src/create-provider';
 import { GS, INITIAL_STATE } from '../utils/initial';
 import spyOn from '../utils/spy-on-global-state-manager';
@@ -16,34 +15,35 @@ describe('Provider.global', (): void => {
 
 
   it('should be an object', (): void => {
-    expect(Provider.global).to.be.an('object');
+    expect(Provider.global).toEqual(expect.any(Object));
   });
 
   it('should not have a setter', (): void => {
     expect((): void => {
       // @ts-ignore: Deliberately throwing an error.
       Provider.global = true;
-    }).to.throw();
+    }).toThrow();
   });
 
   it('should call GlobalStateManager.state', (): void => {
     Provider.global;
-    expect(spy.state.calledOnceWithExactly()).to.equal(true);
+    expect(spy.state).toHaveBeenCalledTimes(1);
+    expect(spy.state).toHaveBeenCalledWith();
   });
 
   it('should return a copy of the state', (): void => {
     const state: GS = Provider.global;
-    expect(state).to.deep.equal(INITIAL_STATE);
-    expect(state).not.to.equal(INITIAL_STATE);
+    expect(state).toEqual(INITIAL_STATE);
+    expect(state).not.toBe(INITIAL_STATE);
   });
 
   it('should update when the state updates', async (): Promise<void> => {
     const STRING = 'create-provider.test.global';
 
-    expect(Provider.global.z).not.to.equal(STRING);
+    expect(Provider.global.z).not.toBe(STRING);
     await Provider.setGlobal({
       z: STRING,
     });
-    expect(Provider.global.z).to.equal(STRING);
+    expect(Provider.global.z).toBe(STRING);
   });
 });

--- a/tests/provider/remove-callback.test.ts
+++ b/tests/provider/remove-callback.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import createProvider, { ReactNProvider } from '../../src/create-provider';
 import spyOn from '../utils/spy-on-global-state-manager';
 
@@ -19,21 +18,22 @@ describe('Provider.removeCallback', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(Provider.removeCallback).to.be.a('function');
-    expect(Provider.removeCallback.length).to.equal(1);
+    expect(Provider.removeCallback).toEqual(expect.any(Function));;
+    expect(Provider.removeCallback.length).toBe(1);
   });
 
   it('should call GlobalStateManager.removeCallback', () => {
     Provider.removeCallback(CALLBACK);
-    expect(spy.removeCallback.calledOnceWith(CALLBACK)).to.equal(true);
+    expect(spy.removeCallback).toHaveBeenCalledTimes(1);
+    expect(spy.removeCallback).toHaveBeenCalledWith(CALLBACK);
   });
 
   it('should return true if the callback existed', (): void => {
     Provider.addCallback(CALLBACK);
-    expect(Provider.removeCallback(CALLBACK)).to.equal(true);
+    expect(Provider.removeCallback(CALLBACK)).toBe(true);
   });
 
   it('should return false if the callback did not exist', (): void => {
-    expect(Provider.removeCallback(CALLBACK)).to.equal(false);
+    expect(Provider.removeCallback(CALLBACK)).toBe(false);
   });
 });

--- a/tests/provider/reset.test.ts
+++ b/tests/provider/reset.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import createProvider, { ReactNProvider } from '../../src/create-provider';
 import spyOn from '../utils/spy-on-global-state-manager';
 
@@ -15,16 +14,17 @@ describe('Provider.reset', (): void => {
 
 
   it('should be a function with no arguments', (): void => {
-    expect(Provider.reset).to.be.a('function');
-    expect(Provider.reset.length).to.equal(0);
+    expect(Provider.reset).toEqual(expect.any(Function));;
+    expect(Provider.reset.length).toBe(0);
   });
 
   it('should call GlobalStateManager.reset', (): void => {
     Provider.reset();
-    expect(spy.reset.calledOnceWithExactly()).to.equal(true);
+    expect(spy.reset).toHaveBeenCalledTimes(1);
+    expect(spy.reset).toHaveBeenCalledWith();
   });
 
   it('should return undefined', (): void => {
-    expect(Provider.reset()).to.be.undefined;
+    expect(Provider.reset()).toBeUndefined();
   });
 });

--- a/tests/provider/set-global.test.ts
+++ b/tests/provider/set-global.test.ts
@@ -69,7 +69,7 @@ describe('Provider.setGlobal', (): void => {
         const set: Promise<GS> = Provider.setGlobal(STATE_CHANGE);
         expect(set).toBeInstanceOf(Promise);
         const value: GS = await set;
-        expect(value).toStrictEqual(NEW_STATE);
+        expect(value).toEqual(NEW_STATE);
       }
     );
 
@@ -81,7 +81,7 @@ describe('Provider.setGlobal', (): void => {
         const set: Promise<GS> = Provider.setGlobal(STATE_CHANGE, NOOP);
         expect(set).toBeInstanceOf(Promise);
         const value: GS = await set;
-        expect(value).toStrictEqual(NEW_STATE);
+        expect(value).toEqual(NEW_STATE);
       }
     );
   });

--- a/tests/provider/use-global.test.ts
+++ b/tests/provider/use-global.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import createProvider, { ReactNProvider } from '../../src/create-provider';
 import { GS, INITIAL_REDUCERS, INITIAL_STATE, R } from '../utils/initial';
 
@@ -14,8 +13,8 @@ describe('Provider.useGlobal', (): void => {
 
 
   it('should be a function with 2 arguments', (): void => {
-    expect(Provider.useGlobal).to.be.a('function');
-    expect(Provider.useGlobal.length).to.equal(2);
+    expect(Provider.useGlobal).toEqual(expect.any(Function));;
+    expect(Provider.useGlobal.length).toBe(2);
   });
 
   it.skip('should do more', (): void => {

--- a/tests/provider/with-global.test.ts
+++ b/tests/provider/with-global.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import createProvider, { ReactNProvider } from '../../src/create-provider';
 import { GS, INITIAL_REDUCERS, INITIAL_STATE, R } from '../utils/initial';
 
@@ -14,8 +13,8 @@ describe('Provider.withGlobal', (): void => {
 
 
   it('should be a function with 2 arguments', (): void => {
-    expect(Provider.withGlobal).to.be.a('function');
-    expect(Provider.withGlobal.length).to.equal(2);
+    expect(Provider.withGlobal).toEqual(expect.any(Function));;
+    expect(Provider.withGlobal.length).toBe(2);
   });
 
   it.skip('should do more', (): void => {

--- a/tests/remove-callback.test.ts
+++ b/tests/remove-callback.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import addCallback from '../src/add-callback';
 import GlobalStateManager from '../src/global-state-manager';
 import removeCallback from '../src/remove-callback';
@@ -24,24 +23,25 @@ describe('removeCallback', (): void => {
 
 
   it('should be a function with 2 arguments', (): void => {
-    expect(removeCallback).to.be.a('function');
-    expect(removeCallback.length).to.equal(2);
+    expect(removeCallback).toEqual(expect.any(Function));
+    expect(removeCallback).toHaveLength(2);
   });
 
   it('should call GlobalStateManager.removeCallback', (): void => {
     removeCallback(globalStateManager, CALLBACK);
-    expect(spy.removeCallback.calledOnceWithExactly(CALLBACK)).to.equal(true);
+    expect(spy.removeCallback).toHaveBeenCalledTimes(1);
+    expect(spy.removeCallback).toHaveBeenCalledWith(CALLBACK);
   });
 
   describe('return value', (): void => {
 
     it('should be true if the callback existed', (): void => {
       addCallback(globalStateManager, CALLBACK);
-      expect(removeCallback(globalStateManager, CALLBACK)).to.equal(true);
+      expect(removeCallback(globalStateManager, CALLBACK)).toBe(true);
     });
 
     it('should be false if the callback did not exist', (): void => {
-      expect(removeCallback(globalStateManager, CALLBACK)).to.equal(false);
+      expect(removeCallback(globalStateManager, CALLBACK)).toBe(false);
     });
   });
 });

--- a/tests/reset-global.test.ts
+++ b/tests/reset-global.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import GlobalStateManager from '../src/global-state-manager';
 import resetGlobal from '../src/reset-global';
 import spyOn from './utils/spy-on-global-state-manager';
@@ -14,16 +13,17 @@ describe('resetGlobal', (): void => {
 
 
   it('should be a function with 1 argument', (): void => {
-    expect(resetGlobal).to.be.a('function');
-    expect(resetGlobal.length).to.equal(1);
+    expect(resetGlobal).toEqual(expect.any(Function));
+    expect(resetGlobal).toHaveLength(1);
   });
 
   it('should call GlobalStateManager.reset', (): void => {
     resetGlobal(globalStateManager);
-    expect(spy.reset.calledOnceWithExactly()).to.equal(true);
+    expect(spy.reset).toHaveBeenCalledTimes(1);
+    expect(spy.reset).toHaveBeenCalledWith();
   });
 
   it('should return undefined', (): void => {
-    expect(resetGlobal(globalStateManager)).to.be.undefined;
+    expect(resetGlobal(globalStateManager)).toBeUndefined();
   });
 });

--- a/tests/use-global.test.ts
+++ b/tests/use-global.test.ts
@@ -1,4 +1,40 @@
-describe('useGlobal', (): void => {
-  it.skip('should do something', (): void => {
+import { renderHook, cleanup, act } from 'react-hooks-testing-library'
+import GlobalStateManager from '../src/global-state-manager';
+import { GS, INITIAL_STATE } from './utils/initial';
+import spyOn from './utils/spy-on-global-state-manager';
+
+import useGlobal from '../src/use-global';
+
+describe.only('useGlobal', (): void => {
+
+  let globalStateManager: GlobalStateManager<GS>;
+  const spy = spyOn('state');
+
+  beforeEach((): void => {
+    globalStateManager = new GlobalStateManager<GS>(INITIAL_STATE);
+  });
+
+  afterEach(cleanup);
+
+  it('return default global state and setter', (): void => {
+    const { result } = renderHook(() => useGlobal(globalStateManager));
+
+    expect(result.current).toEqual([INITIAL_STATE, expect.any(Function)]);
+
+    // call the setter
+    act(() => { result.current[1]({ x: true }); })
+
+    expect(result.current).toEqual([{ ...INITIAL_STATE, x: true }, expect.any(Function)]);
+  });
+
+  it('return scoped global state and setter', (): void => {
+    const { result } = renderHook(() => useGlobal(globalStateManager, 'x'));
+
+    expect(result.current).toEqual([false, expect.any(Function)]);
+
+    // call the setter
+    act(() => { result.current[1](true); })
+
+    expect(result.current).toEqual([true, expect.any(Function)]);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3283,6 +3283,14 @@ react-dom@^16.8.6:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
+react-hooks-testing-library@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/react-hooks-testing-library/-/react-hooks-testing-library-0.4.0.tgz#601f7eda1e817f57a86ef3fe0a17a1fdd771122b"
+  integrity sha512-N/MBIlycPeeAOJwFloUnwpKLBDH2y0L17srRMw1bI/dCyYYC2zKwg9Xccxwy4HFVAGfO9uweVrAGFvOnc6YvUw==
+  dependencies:
+    "@babel/runtime" "^7.4.2"
+    react-testing-library "^6.0.3"
+
 react-is@^16.8.1:
   version "16.8.5"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.5.tgz#c54ac229dd66b5afe0de5acbe47647c3da692ff8"
@@ -3292,7 +3300,7 @@ react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-testing-library@^6.0.4:
+react-testing-library@^6.0.3, react-testing-library@^6.0.4:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-6.0.4.tgz#18aec01bcb8505df5da612c68cf0be134e0f44ae"
   integrity sha512-7D6/hIvyOr8c51UHgH9CL2ZlzYPFI2Jmjm9hMuUvKR9mIiOEaWr5A7CZ9r7zO9tCK5D15r4uj71BHfJ7Zus3qw==


### PR DESCRIPTION
I have a vested interest in how convenient this library is, so I figured I would help out where possible. I saw you switched to jest, which is something I did in a branch of my own, so I converted the tests for you and added a couple of tests for `use-global`.