### PR TITLE
Converts componentWillMount with UNSAFE_componentWillMount

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -58,10 +58,10 @@ export default function ReactN<
       }
     }
 
-    public componentWillUpdate(...args: [ P, S, any ]): void {
+    public UNSAFE_componentWillUpdate(...args: [ P, S, any ]): void {
       ReactNComponentWillUpdate(this);
-      if (super.componentWillUpdate) {
-        super.componentWillUpdate(...args);
+      if (super.UNSAFE_componentWillUpdate) {
+        super.UNSAFE_componentWillUpdate(...args);
       }
     }
 

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -59,19 +59,18 @@ export default function ReactN<
     }
 
     public UNSAFE_componentWillUpdate(...args: [ P, S, any ]): void {
-      if (parseInt(version.split('.')[0]) > 16 ||
-      (parseInt(version.split('.')[0]) == 16 && parseInt(version.split('.')[1]) >= 3)){
+      const [ rVerMaj, rVerMin ] = version.split('.').map(parseInt)
+      if (rVerMaj > 16 || (rVerMaj === 16 && rVerMin >= 3)) {
         ReactNComponentWillUpdate(this);
       }
       if (super.UNSAFE_componentWillUpdate) {
         super.UNSAFE_componentWillUpdate(...args);
       }
-      
     }
 
     public componentWillUpdate(...args: [ P, S, any ]): void {
-      if (parseInt(version.split('.')[0]) < 16 ||
-      (parseInt(version.split('.')[0]) == 16 && parseInt(version.split('.')[1]) < 3)){
+      const [ rVerMaj, rVerMin ] = version.split('.').map(parseInt)
+      if (rVerMaj < 16 || (rVerMaj === 16 && rVerMin < 3)) {
         ReactNComponentWillUpdate(this);
       }
       if (super.componentWillUpdate) {

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -59,7 +59,7 @@ export default function ReactN<
     }
 
     public UNSAFE_componentWillUpdate(...args: [ P, S, any ]): void {
-      const [ rVerMaj, rVerMin ] = version.split('.').map(parseInt)
+      const [ rVerMaj, rVerMin ] = version.split('.').map((v): number => parseInt(v));
       if (rVerMaj > 16 || (rVerMaj === 16 && rVerMin >= 3)) {
         ReactNComponentWillUpdate(this);
       }
@@ -69,7 +69,7 @@ export default function ReactN<
     }
 
     public componentWillUpdate(...args: [ P, S, any ]): void {
-      const [ rVerMaj, rVerMin ] = version.split('.').map(parseInt)
+      const [ rVerMaj, rVerMin ] = version.split('.').map((v): number => parseInt(v));
       if (rVerMaj < 16 || (rVerMaj === 16 && rVerMin < 3)) {
         ReactNComponentWillUpdate(this);
       }

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,4 +1,4 @@
-import { ComponentClass } from 'react';
+import { ComponentClass, version } from 'react';
 import { Reducers, State } from '../default';
 import Callback from '../types/callback';
 import { ReactNComponentClass } from '../types/component-class';
@@ -59,9 +59,23 @@ export default function ReactN<
     }
 
     public UNSAFE_componentWillUpdate(...args: [ P, S, any ]): void {
-      ReactNComponentWillUpdate(this);
+      if (parseInt(version.split('.')[0]) > 16 ||
+      (parseInt(version.split('.')[0]) == 16 && parseInt(version.split('.')[1]) >= 3)){
+        ReactNComponentWillUpdate(this);
+      }
       if (super.UNSAFE_componentWillUpdate) {
         super.UNSAFE_componentWillUpdate(...args);
+      }
+      
+    }
+
+    public componentWillUpdate(...args: [ P, S, any ]): void {
+      if (parseInt(version.split('.')[0]) < 16 ||
+      (parseInt(version.split('.')[0]) == 16 && parseInt(version.split('.')[1]) < 3)){
+        ReactNComponentWillUpdate(this);
+      }
+      if (super.componentWillUpdate) {
+        super.componentWillUpdate(...args);
       }
     }
 

--- a/src/utils/bind-lifecycle-methods.ts
+++ b/src/utils/bind-lifecycle-methods.ts
@@ -44,7 +44,7 @@ export default function bindLifecycleMethods<
 
     // Warning: If componentWillUpdate is defined in the constructor (or as an
     //   arrow function), this will be overridden.
-    that.componentWillUpdate = (): void => {
+    that.UNSAFE_componentWillUpdate = (): void => {
       ReactNComponentWillUpdate(that);
     };
   }

--- a/src/utils/bind-lifecycle-methods.ts
+++ b/src/utils/bind-lifecycle-methods.ts
@@ -1,5 +1,6 @@
 import { Reducers, State } from '../../default';
 import { ReactNComponent, ReactNPureComponent } from '../../types/component';
+import React = require('react');
 import {
   ReactNComponentWillUnmount,
   ReactNComponentWillUpdate,
@@ -41,11 +42,18 @@ export default function bindLifecycleMethods<
     // !componentWillUpdateInstance(that) &&
     !componentWillUpdatePrototype(that)
   ) {
-
+    const isDeprecated = parseInt(React.version.split('.')[0]) > 16 ||
+    (parseInt(React.version.split('.')[0]) == 16 && parseInt(React.version.split('.')[1]) >= 3)
+    if (isDeprecated) {
+      that.UNSAFE_componentWillUpdate = (): void => {
+        ReactNComponentWillUpdate(that);
+      };
+    } else {
+      that.componentWillUpdate = (): void => {
+        ReactNComponentWillUpdate(that);
+      };
+    }
     // Warning: If componentWillUpdate is defined in the constructor (or as an
     //   arrow function), this will be overridden.
-    that.UNSAFE_componentWillUpdate = (): void => {
-      ReactNComponentWillUpdate(that);
-    };
   }
 };

--- a/src/utils/bind-lifecycle-methods.ts
+++ b/src/utils/bind-lifecycle-methods.ts
@@ -42,7 +42,7 @@ export default function bindLifecycleMethods<
     // !componentWillUpdateInstance(that) &&
     !componentWillUpdatePrototype(that)
   ) {
-    const [ rVerMaj, rVerMin ] = React.version.split('.').map(parseInt)
+    const [ rVerMaj, rVerMin ] = React.version.split('.').map((v): number => parseInt(v));
     if (rVerMaj > 16 || (rVerMaj === 16 && rVerMin >= 3)) {
       that.UNSAFE_componentWillUpdate = (): void => {
         ReactNComponentWillUpdate(that);

--- a/src/utils/bind-lifecycle-methods.ts
+++ b/src/utils/bind-lifecycle-methods.ts
@@ -42,9 +42,8 @@ export default function bindLifecycleMethods<
     // !componentWillUpdateInstance(that) &&
     !componentWillUpdatePrototype(that)
   ) {
-    const isDeprecated = parseInt(React.version.split('.')[0]) > 16 ||
-    (parseInt(React.version.split('.')[0]) == 16 && parseInt(React.version.split('.')[1]) >= 3)
-    if (isDeprecated) {
+    const [ rVerMaj, rVerMin ] = React.version.split('.').map(parseInt)
+    if (rVerMaj > 16 || (rVerMaj === 16 && rVerMin >= 3)) {
       that.UNSAFE_componentWillUpdate = (): void => {
         ReactNComponentWillUpdate(that);
       };

--- a/src/utils/component-will-update.ts
+++ b/src/utils/component-will-update.ts
@@ -46,10 +46,10 @@ export const componentWillUpdatePrototype = <
 ): boolean => {
   const proto: ReactNComponent | ReactNPureComponent =
     Object.getPrototypeOf(that);
-  if (Object.prototype.hasOwnProperty.call(proto, 'componentWillUpdate')) {
-    that.componentWillUpdate = (...args: [ P, S, any ]): void => {
+  if (Object.prototype.hasOwnProperty.call(proto, 'UNSAFE_componentWillUpdate')) {
+    that.UNSAFE_componentWillUpdate = (...args: [ P, S, any ]): void => {
       ReactNComponentWillUpdate(that);
-      proto.componentWillUpdate.bind(that)(...args);
+      proto.UNSAFE_componentWillUpdate.bind(that)(...args);
     };
     return true;
   }

--- a/src/utils/component-will-update.ts
+++ b/src/utils/component-will-update.ts
@@ -53,5 +53,12 @@ export const componentWillUpdatePrototype = <
     };
     return true;
   }
+  if (Object.prototype.hasOwnProperty.call(proto, 'componentWillUpdate')) {
+    that.componentWillUpdate = (...args: [ P, S, any ]): void => {
+      ReactNComponentWillUpdate(that);
+      proto.componentWillUpdate.bind(that)(...args);
+    };
+    return true;
+  }
   return false;
 };


### PR DESCRIPTION
Hi, 
I have converted componentWillMount with UNSAFE_componentWillMount and tried to maintain compatibility with older versions of React by using the appropriate method depending from the react version in use.

I should have covered all edge cases (i.e. react version >= 16.3 and main project does not yet adds UNSAFE).

I have made a separate GitHub repo with the compiled version so if somebody wants to test this in their project they can just do a 

`yarn add SIAPCN/reactnUnsafe`

as drop in replacement for reactn 2.2.4 with this workaround and no warnings.

Regards,
Umberto