### PR TITLE
✨using shouldComponentUpdate from React 16.3.x

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -8,7 +8,6 @@ import {
   // createReactNGetDerivedStateFromProps,
   ReactNComponentWillUnmount,
   ReactNComponentWillUpdate,
-  // ReactNShouldComponentUpdate,
   ReactNDispatch,
   ReactNGlobal,
   ReactNGlobalCallback,
@@ -24,7 +23,6 @@ const isSetGlobalCallback = false;
 
 const [ rVerMaj, rVerMin ] = version.split('.').map((v): number => parseInt(v));
 const isUsingOldReact = rVerMaj < 16 || (rVerMaj === 16 && rVerMin < 3);
-const isPureComponent = (name: string): boolean => name === 'DecoratedCwuPrototype-ReactN'
 
 // Get the name of a Component.
 const componentName = <
@@ -73,23 +71,13 @@ export default function ReactN<
     }
 
     public UNSAFE_componentWillUpdate(...args: [ P, S, any ]): void {
-      if (!isUsingOldReact /* && isPureComponent(this.constructor.name) see shouldComponentUpdate */) {
+      if (!isUsingOldReact) {
         ReactNComponentWillUpdate(this);
       }
       if (super.UNSAFE_componentWillUpdate) {
         super.UNSAFE_componentWillUpdate(...args);
       }
     }
-
-    /*
-    // Commenting this out...seems that shouldComponentUpdate is not firing for decorated components      
-    public shouldComponentUpdate(...args: [ P, S, any ]): boolean {
-      console.log('I'm firing!'); <= This never shows in tests
-      if (!isUsingOldReact && !isPureComponent(this.constructor.name)) {
-        ReactNShouldComponentUpdate(this);
-      }
-      return super.shouldComponentUpdate ? super.shouldComponentUpdate(...args) : true;
-    } */
 
     public get dispatch(): Dispatchers<G, R> {
       return ReactNDispatch<G, R>();
@@ -122,11 +110,6 @@ export default function ReactN<
     ReactNComponent.getDerivedStateFromProps = createReactNGetDerivedStateFromProps(Component);
   }
   */
-
-  if (isPureComponent(DecoratedReactNComponent.displayName)) {
-    // Must remove shouldComponentUpdate from prototype for pure components or it will get warning and side effects
-    delete DecoratedReactNComponent.prototype.shouldComponentUpdate
-  }
 
   return DecoratedReactNComponent;
 };

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -8,6 +8,7 @@ import {
   // createReactNGetDerivedStateFromProps,
   ReactNComponentWillUnmount,
   ReactNComponentWillUpdate,
+  ReactNCShouldComponentUpdate,
   ReactNDispatch,
   ReactNGlobal,
   ReactNGlobalCallback,
@@ -58,14 +59,12 @@ export default function ReactN<
       }
     }
 
-    public UNSAFE_componentWillUpdate(...args: [ P, S, any ]): void {
+    public shouldComponentUpdate(...args: [ P, S, any ]): boolean {
       const [ rVerMaj, rVerMin ] = version.split('.').map((v): number => parseInt(v));
       if (rVerMaj > 16 || (rVerMaj === 16 && rVerMin >= 3)) {
-        ReactNComponentWillUpdate(this);
+        ReactNCShouldComponentUpdate(this);
       }
-      if (super.UNSAFE_componentWillUpdate) {
-        super.UNSAFE_componentWillUpdate(...args);
-      }
+      return super.shouldComponentUpdate ? super.shouldComponentUpdate(...args) : true;
     }
 
     public componentWillUpdate(...args: [ P, S, any ]): void {

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -54,7 +54,7 @@ export function ReactNComponentWillUnmount<G extends {} = State>(
 
 
 
-// this.componentWillUnmount
+// this.componentWillUpdate
 export function ReactNComponentWillUpdate<G extends {} = State>(
   that: ReactNComponent<any, any, G> | ReactNPureComponent<any, any, G>,
 ): void {
@@ -63,6 +63,14 @@ export function ReactNComponentWillUpdate<G extends {} = State>(
   getGlobalStateManager<G>().removePropertyListener(that._globalCallback);
 }
 
+// this.shouldComponentUpdate
+export function ReactNCShouldComponentUpdate<G extends {} = State>(
+  that: ReactNComponent<any, any, G> | ReactNPureComponent<any, any, G>,
+): void {
+
+  // No longer re-render this component on global state change.
+  getGlobalStateManager<G>().removePropertyListener(that._globalCallback);
+}
 
 
 // this.dispatch

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -64,7 +64,7 @@ export function ReactNComponentWillUpdate<G extends {} = State>(
 }
 
 // this.shouldComponentUpdate
-export function ReactNCShouldComponentUpdate<G extends {} = State>(
+export function ReactNShouldComponentUpdate<G extends {} = State>(
   that: ReactNComponent<any, any, G> | ReactNPureComponent<any, any, G>,
 ): void {
 

--- a/src/utils/bind-lifecycle-methods.ts
+++ b/src/utils/bind-lifecycle-methods.ts
@@ -4,6 +4,7 @@ import React = require('react');
 import {
   ReactNComponentWillUnmount,
   ReactNComponentWillUpdate,
+  ReactNCShouldComponentUpdate,
 } from '../methods';
 import {
   // componentWillUnmountInstance,
@@ -13,6 +14,10 @@ import {
   // componentWillUpdateInstance,
   componentWillUpdatePrototype,
 } from './component-will-update';
+import {
+  // shouldComponentUpdateInstance,
+  shouldComponentUpdatePrototype,
+} from './should-component-update';
 
 
 
@@ -38,21 +43,31 @@ export default function bindLifecycleMethods<
     };
   }
 
+  const [ rVerMaj, rVerMin ] = React.version.split('.').map((v): number => parseInt(v));
+
   if (
     // !componentWillUpdateInstance(that) &&
-    !componentWillUpdatePrototype(that)
+    !componentWillUpdatePrototype(that) &&
+    ((rVerMaj < 16 || (rVerMaj === 16 && rVerMin < 3))) // Using old react version
   ) {
-    const [ rVerMaj, rVerMin ] = React.version.split('.').map((v): number => parseInt(v));
-    if (rVerMaj > 16 || (rVerMaj === 16 && rVerMin >= 3)) {
-      that.UNSAFE_componentWillUpdate = (): void => {
-        ReactNComponentWillUpdate(that);
-      };
-    } else {
-      that.componentWillUpdate = (): void => {
-        ReactNComponentWillUpdate(that);
-      };
-    }
+    that.componentWillUpdate = (): void => {
+      ReactNComponentWillUpdate(that);
+    };
     // Warning: If componentWillUpdate is defined in the constructor (or as an
     //   arrow function), this will be overridden.
+  }
+
+  if (
+    // !shouldComponentUpdateInstance(that) &&
+    !shouldComponentUpdatePrototype(that) &&
+    ((rVerMaj > 16 || (rVerMaj === 16 && rVerMin >= 3))) // Using new react version with deprecated componentWillUpdate
+  ) {
+
+    // Warning: If shouldComponentUpdate is defined in the constructor (or as an
+    //   arrow function), this will be overridden.
+    that.shouldComponentUpdate = (): boolean => {
+      ReactNCShouldComponentUpdate(that);
+      return true; // If shouldComponentUpdate is not defined it defaults to true
+    };
   }
 };

--- a/src/utils/bind-lifecycle-methods.ts
+++ b/src/utils/bind-lifecycle-methods.ts
@@ -4,7 +4,7 @@ import React = require('react');
 import {
   ReactNComponentWillUnmount,
   ReactNComponentWillUpdate,
-  ReactNCShouldComponentUpdate,
+  ReactNShouldComponentUpdate,
 } from '../methods';
 import {
   // componentWillUnmountInstance,
@@ -44,31 +44,43 @@ export default function bindLifecycleMethods<
   }
 
   const [ rVerMaj, rVerMin ] = React.version.split('.').map((v): number => parseInt(v));
+  const isPureComponent = React.PureComponent && (that instanceof React.PureComponent);
+  const isUsingOldReact = rVerMaj < 16 || (rVerMaj === 16 && rVerMin < 3);
 
   if (
     // !componentWillUpdateInstance(that) &&
-    !componentWillUpdatePrototype(that) &&
-    ((rVerMaj < 16 || (rVerMaj === 16 && rVerMin < 3))) // Using old react version
+    isUsingOldReact && !componentWillUpdatePrototype(that)
   ) {
-
+    // This will fire if using an Old React Version
     // Warning: If componentWillUpdate is defined in the constructor (or as an
     //   arrow function), this will be overridden.
     that.componentWillUpdate = (): void => {
       ReactNComponentWillUpdate(that);
     };
-    
+  }
+
+  if (
+    // !componentWillUpdateInstance(that) &&
+    !isUsingOldReact && isPureComponent && !componentWillUpdatePrototype(that)
+  ) {
+    // This will fire if using New React Versions and component is Pure.
+    // TODO: Firgure out a way to move out UNSAFE methods as can't use shouldComponentUpdate on Pure Components.
+    // Warning: If UNSAFE_componentWillUpdate is defined in the constructor (or as an
+    //   arrow function), this will be overridden.
+    that.UNSAFE_componentWillUpdate = (): void => {
+      ReactNComponentWillUpdate(that);
+    };
   }
 
   if (
     // !shouldComponentUpdateInstance(that) &&
-    !shouldComponentUpdatePrototype(that) &&
-    ((rVerMaj > 16 || (rVerMaj === 16 && rVerMin >= 3))) // Using new react version with deprecated componentWillUpdate
+    !isUsingOldReact && !isPureComponent && !shouldComponentUpdatePrototype(that)
   ) {
-
+    // This will fire if using New React Versions and regular components
     // Warning: If shouldComponentUpdate is defined in the constructor (or as an
     //   arrow function), this will be overridden.
     that.shouldComponentUpdate = (): boolean => {
-      ReactNCShouldComponentUpdate(that);
+      ReactNShouldComponentUpdate(that);
       return true; // If shouldComponentUpdate is not defined it defaults to true
     };
   }

--- a/src/utils/bind-lifecycle-methods.ts
+++ b/src/utils/bind-lifecycle-methods.ts
@@ -50,11 +50,13 @@ export default function bindLifecycleMethods<
     !componentWillUpdatePrototype(that) &&
     ((rVerMaj < 16 || (rVerMaj === 16 && rVerMin < 3))) // Using old react version
   ) {
+
+    // Warning: If componentWillUpdate is defined in the constructor (or as an
+    //   arrow function), this will be overridden.
     that.componentWillUpdate = (): void => {
       ReactNComponentWillUpdate(that);
     };
-    // Warning: If componentWillUpdate is defined in the constructor (or as an
-    //   arrow function), this will be overridden.
+    
   }
 
   if (

--- a/src/utils/component-will-update.ts
+++ b/src/utils/component-will-update.ts
@@ -48,7 +48,7 @@ export const componentWillUpdatePrototype = <
     Object.getPrototypeOf(that);
   const [ rVerMaj, rVerMin ] = React.version.split('.').map((v): number => parseInt(v));
   if (Object.prototype.hasOwnProperty.call(proto, 'componentWillUpdate')
-    && ((rVerMaj < 16 || (rVerMaj === 16 && rVerMin < 3)))) { // Using old react version)
+    && ((rVerMaj < 16 || (rVerMaj === 16 && rVerMin < 3)))) { // Using old react version
     that.componentWillUpdate = (...args: [ P, S, any ]): void => {
       ReactNComponentWillUpdate(that);
       proto.componentWillUpdate.bind(that)(...args);

--- a/src/utils/component-will-update.ts
+++ b/src/utils/component-will-update.ts
@@ -1,7 +1,7 @@
 import { Reducers, State } from '../../default';
 import { ReactNComponent, ReactNPureComponent } from '../../types/component';
 import { ReactNComponentWillUpdate } from '../methods';
-
+import React = require('react');
 
 
 /*
@@ -46,14 +46,9 @@ export const componentWillUpdatePrototype = <
 ): boolean => {
   const proto: ReactNComponent | ReactNPureComponent =
     Object.getPrototypeOf(that);
-  if (Object.prototype.hasOwnProperty.call(proto, 'UNSAFE_componentWillUpdate')) {
-    that.UNSAFE_componentWillUpdate = (...args: [ P, S, any ]): void => {
-      ReactNComponentWillUpdate(that);
-      proto.UNSAFE_componentWillUpdate.bind(that)(...args);
-    };
-    return true;
-  }
-  if (Object.prototype.hasOwnProperty.call(proto, 'componentWillUpdate')) {
+  const [ rVerMaj, rVerMin ] = React.version.split('.').map((v): number => parseInt(v));
+  if (Object.prototype.hasOwnProperty.call(proto, 'componentWillUpdate')
+    && ((rVerMaj < 16 || (rVerMaj === 16 && rVerMin < 3)))) { // Using old react version)
     that.componentWillUpdate = (...args: [ P, S, any ]): void => {
       ReactNComponentWillUpdate(that);
       proto.componentWillUpdate.bind(that)(...args);

--- a/src/utils/should-component-update.ts
+++ b/src/utils/should-component-update.ts
@@ -1,6 +1,6 @@
 import { Reducers, State } from '../../default';
 import { ReactNComponent, ReactNPureComponent } from '../../types/component';
-import { ReactNCShouldComponentUpdate } from '../methods';
+import { ReactNShouldComponentUpdate } from '../methods';
 import React = require('react');
 
 
@@ -51,7 +51,7 @@ export const shouldComponentUpdatePrototype = <
   if (Object.prototype.hasOwnProperty.call(proto, 'shouldComponentUpdate')
     && ((rVerMaj > 16 || (rVerMaj === 16 && rVerMin >= 3)))) {
     that.shouldComponentUpdate = (...args: [ P, S, any ]): boolean => {
-      ReactNCShouldComponentUpdate(that);
+      ReactNShouldComponentUpdate(that);
       return proto.shouldComponentUpdate.bind(that)(...args); // Returns outcome of shouldComponentUpdate method
     };
     return true;

--- a/src/utils/should-component-update.ts
+++ b/src/utils/should-component-update.ts
@@ -1,0 +1,57 @@
+import { Reducers, State } from '../../default';
+import { ReactNComponent, ReactNPureComponent } from '../../types/component';
+import { ReactNCShouldComponentUpdate } from '../methods';
+
+
+
+/*
+type ShouldComponentUpdate<P extends {} = {}, S extends {} = {}> =
+  (nextProps: P, nextState: S, context: any) => void;
+*/
+
+
+
+// this.shouldComponentUpdate on instance
+/*
+export const shouldComponentUpdateInstance = <
+  P extends {} = {},
+  S extends {} = {},
+  G extends {} = State,
+  R extends {} = Reducers,
+  SS = any,
+>(
+  that: ReactNComponent<P, S, G, R, SS> | ReactNPureComponent<P, S, G, R, SS>,
+): boolean => {
+  if (Object.prototype.hasOwnProperty.call(that, 'shouldComponentUpdate')) {
+    const instanceCwu: ShouldComponentUpdate<P, S> = that.shouldComponentUpdate;
+    that.shouldComponentUpdate = (...args: [ P, S, any ]): void => {
+      ReactNShouldComponentUpdate(that);
+      instanceCwu(...args);
+    };
+    return true;
+  }
+  return false;
+};
+*/
+
+// this.shouldComponentUpdate on prototype
+export const shouldComponentUpdatePrototype = <
+  P extends {} = {},
+  S extends {} = {},
+  G extends {} = State,
+  R extends {} = Reducers,
+  SS = any,
+>(
+  that: ReactNComponent<P, S, G, R, SS> | ReactNPureComponent<P, S, G, R, SS>,
+): boolean => {
+
+  const proto: ReactNComponent | ReactNPureComponent =
+    Object.getPrototypeOf(that);
+  if (Object.prototype.hasOwnProperty.call(proto, 'shouldComponentUpdate')) {
+    that.shouldComponentUpdate = (...args: [ P, S, any ]): boolean => {
+      ReactNCShouldComponentUpdate(that);
+      return proto.shouldComponentUpdate.bind(that)(...args); // Returns outcome of shouldComponentUpdate method
+    };
+  }
+  return false;
+};

--- a/src/utils/should-component-update.ts
+++ b/src/utils/should-component-update.ts
@@ -1,7 +1,7 @@
 import { Reducers, State } from '../../default';
 import { ReactNComponent, ReactNPureComponent } from '../../types/component';
 import { ReactNCShouldComponentUpdate } from '../methods';
-
+import React = require('react');
 
 
 /*
@@ -47,11 +47,14 @@ export const shouldComponentUpdatePrototype = <
 
   const proto: ReactNComponent | ReactNPureComponent =
     Object.getPrototypeOf(that);
-  if (Object.prototype.hasOwnProperty.call(proto, 'shouldComponentUpdate')) {
+  const [ rVerMaj, rVerMin ] = React.version.split('.').map((v): number => parseInt(v));
+  if (Object.prototype.hasOwnProperty.call(proto, 'shouldComponentUpdate')
+    && ((rVerMaj > 16 || (rVerMaj === 16 && rVerMin >= 3)))) {
     that.shouldComponentUpdate = (...args: [ P, S, any ]): boolean => {
       ReactNCShouldComponentUpdate(that);
       return proto.shouldComponentUpdate.bind(that)(...args); // Returns outcome of shouldComponentUpdate method
     };
+    return true;
   }
   return false;
 };


### PR DESCRIPTION
Hello, 
as I am getting a better understanding of how internals of ReactN works I switched from the UNSAFE_componentWillUpdate to shouldComponentUpdate only if using React 16.3.x onwards, so the behavior for older Reacts is unchanged.

The only difference in behavior between componentWillUpdate and shouldComponentUpdate is that the first doesn't return anything while the second must return true if you want to simulate a function not been defined un user's class.

This should ensure compatibility with React 17.x onwards without using UNSAFE's methods.

Still a NOOB on TypeScript, apologizes if I used improper syntax, but all checks pass.