### PR TITLE
export Setter

### DIFF
--- a/types/use-global.d.ts
+++ b/types/use-global.d.ts
@@ -6,7 +6,7 @@ export type GlobalTuple<GS> = [
   (newGlobalState: NewGlobalState<GS>, callback?: Callback<GS>) => Promise<GS>,
 ];
 
-type Setter<G extends {}, P extends keyof G> =
+export type Setter<G extends {}, P extends keyof G> =
   (newValue: G[P], callback?: Callback<G>) => Promise<G>;
 
 export type StateTuple<G extends {}, P extends keyof G> = [


### PR DESCRIPTION
I'm passing the setter for a global state property on to a chuld object. As Charles pointed out, its also possible to just call useGlobal from the child component. But in my case I use specific data container components to collect all data and want to pass on everything as props down the component tree